### PR TITLE
feat: add slash-commands skill and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,24 +35,71 @@ Uninstall if needed:
 
 ### Commands
 
-| Command | Description |
-|---------|-------------|
-| `/toolkit:skill-history` | Show skills invoked this session |
-| `/toolkit:agent-history` | Show agents spawned this session |
+#### `/toolkit:skill-history`
+
+> Which skills have been used in this session?
+
+- Searches session log for skill invocations
+- Shows timestamp, skill name, and trigger
+
+#### `/toolkit:agent-history`
+
+> What agents have been spawned?
+
+- Searches session log for agent spawns
+- Shows timestamp, agent name, and task
 
 ### Skills
 
-| Skill | Description |
-|-------|-------------|
-| `research` | Structured research methodology with evidence requirements |
-| `claude-code-hook-development` | Create hooks for guardrails, automations, and policy enforcement |
-| `skill-development` | Create effective Claude Code skills |
+#### `research`
+
+> Research options for implementing OAuth in a Node.js app
+
+- Searches web and clones GitHub repos
+- Requires 2-3 sources before recommending
+- Saves findings to `./scratch/research/`
+
+#### `claude-code-hook-development`
+
+> Create a hook that runs tests before git push
+
+- Creates shell scripts in `.claude/hooks/`
+- Configures hook events in `.claude/settings.json`
+- Supports blocking (exit 2) and non-blocking hooks
+
+#### `skill-development`
+
+> Create a skill for TypeScript development
+
+- Creates `SKILL.md` with frontmatter
+- Organizes references in subdirectories
+- Follows progressive disclosure pattern
+
+#### `agent-development`
+
+> Create an agent for code review
+
+- Creates agent markdown with YAML frontmatter
+- Applies color conventions (blue=plan, green=create, etc.)
+- Configures tools and permissions
+
+#### `claude-code-slash-commands`
+
+> Create a slash command for generating changelogs
+
+- Creates command markdown in `.claude/commands/`
+- Configures frontmatter (allowed-tools, argument-hint)
+- Supports `$ARGUMENTS` and positional `$1`, `$2` params
 
 ### Agents
 
-| Agent | Description |
-|-------|-------------|
-| `researcher` | Research technical solutions via web search and GitHub repos |
+#### `researcher`
+
+> Research how to implement terminal recording in an MCP server
+
+- Searches web for documentation and repos
+- Clones GitHub repos to `/tmp` for examination
+- Presents options with pros/cons and sources
 
 ## License
 

--- a/plugins/toolkit/skills/claude-code-slash-commands/SKILL.md
+++ b/plugins/toolkit/skills/claude-code-slash-commands/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: claude-code-slash-commands
+description: This skill should be used when the user asks to "create a command", "write a slash command", "build a plugin command", or wants to add custom commands to Claude Code.
+---
+
+# Slash Command Development
+
+Create custom slash commands for Claude Code.
+
+## Quick Reference
+
+You MUST read these references for detailed guidance:
+
+- [Official Documentation](./references/official-docs.md) - Anthropic's slash command guide
+
+## Command Structure
+
+Commands are Markdown files in specific locations:
+
+| Scope | Location | Description suffix |
+|-------|----------|-------------------|
+| Project | `.claude/commands/` | `(project)` |
+| Personal | `~/.claude/commands/` | `(user)` |
+| Plugin | `commands/` in plugin root | `(plugin)` |
+
+## Basic Command
+
+```markdown
+---
+description: Brief description of what this command does
+---
+
+Your prompt instructions here.
+```
+
+## Frontmatter Options
+
+```yaml
+---
+allowed-tools: Bash(git:*), Read
+argument-hint: [filename] [options]
+description: What this command does
+model: claude-3-5-haiku-20241022
+disable-model-invocation: false
+---
+```
+
+| Field | Purpose |
+|-------|---------|
+| `allowed-tools` | Tools the command can use |
+| `argument-hint` | Shows in autocomplete (e.g., `[message]`) |
+| `description` | Brief description (required for SlashCommand tool) |
+| `model` | Specific model to use |
+| `disable-model-invocation` | Prevent programmatic invocation |
+
+## Arguments
+
+**All arguments:**
+```markdown
+Fix issue #$ARGUMENTS following our coding standards
+```
+
+**Positional arguments:**
+```markdown
+Review PR #$1 with priority $2 and assign to $3
+```
+
+## Dynamic Content
+
+**Bash execution** (prefix with `!`):
+```markdown
+Current branch: !`git branch --show-current`
+Recent commits: !`git log --oneline -5`
+```
+
+**File references** (prefix with `@`):
+```markdown
+Review the implementation in @src/utils/helpers.js
+```
+
+## Namespacing
+
+Subdirectories group related commands:
+
+- `.claude/commands/frontend/test.md` → `/test` shows `(project:frontend)`
+- `.claude/commands/backend/test.md` → `/test` shows `(project:backend)`
+
+## Checklist
+
+- [ ] Description filled in frontmatter
+- [ ] `argument-hint` if command takes arguments
+- [ ] `allowed-tools` if using Bash or specific tools
+- [ ] Test with `/command-name --help` style invocation

--- a/plugins/toolkit/skills/claude-code-slash-commands/references/official-docs.md
+++ b/plugins/toolkit/skills/claude-code-slash-commands/references/official-docs.md
@@ -1,0 +1,180 @@
+# Official Slash Commands Documentation
+
+> Source: https://code.claude.com/docs/en/slash-commands
+
+## Custom Slash Commands
+
+Custom slash commands allow you to define frequently used prompts as Markdown files that Claude Code can execute. Commands are organized by scope (project-specific or personal) and support namespacing through directory structures.
+
+Slash command autocomplete works anywhere in your input, not just at the beginning. Type `/` at any position to see available commands.
+
+## Syntax
+
+```
+/<command-name> [arguments]
+```
+
+### Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `<command-name>` | Name derived from the Markdown filename (without `.md` extension) |
+| `[arguments]` | Optional arguments passed to the command |
+
+## Command Types
+
+### Project Commands
+
+Commands stored in your repository and shared with your team. When listed in `/help`, these commands show "(project)" after their description.
+
+**Location:** `.claude/commands/`
+
+```bash
+# Create a project command
+mkdir -p .claude/commands
+echo "Analyze this code for performance issues and suggest optimizations:" > .claude/commands/optimize.md
+```
+
+### Personal Commands
+
+Commands available across all your projects. When listed in `/help`, these commands show "(user)" after their description.
+
+**Location:** `~/.claude/commands/`
+
+```bash
+# Create a personal command
+mkdir -p ~/.claude/commands
+echo "Review this code for security vulnerabilities:" > ~/.claude/commands/security-review.md
+```
+
+## Features
+
+### Namespacing
+
+Use subdirectories to group related commands. Subdirectories appear in the command description but don't affect the command name.
+
+For example:
+- `.claude/commands/frontend/component.md` creates `/component` with description "(project:frontend)"
+- `~/.claude/commands/component.md` creates `/component` with description "(user)"
+
+If a project command and user command share the same name, the project command takes precedence and the user command is silently ignored.
+
+Commands in different subdirectories can share names since the subdirectory appears in the description to distinguish them.
+
+### Arguments
+
+**All arguments with `$ARGUMENTS`:**
+
+The `$ARGUMENTS` placeholder captures all arguments passed to the command:
+
+```markdown
+# Command definition
+Fix issue #$ARGUMENTS following our coding standards
+
+# Usage: /fix-issue 123 high-priority
+# $ARGUMENTS becomes: "123 high-priority"
+```
+
+**Individual arguments with `$1`, `$2`, etc.:**
+
+Access specific arguments individually using positional parameters:
+
+```markdown
+# Command definition
+Review PR #$1 with priority $2 and assign to $3
+
+# Usage: /review-pr 456 high alice
+# $1 becomes "456", $2 becomes "high", $3 becomes "alice"
+```
+
+### Bash Command Execution
+
+Execute bash commands before the slash command runs using the `!` prefix. The output is included in the command context. You must include `allowed-tools` with the Bash tool.
+
+```markdown
+---
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+description: Create a git commit
+---
+
+## Context
+
+- Current git status: !`git status`
+- Current git diff: !`git diff HEAD`
+- Current branch: !`git branch --show-current`
+- Recent commits: !`git log --oneline -10`
+
+## Your task
+
+Based on the above changes, create a single git commit.
+```
+
+### File References
+
+Include file contents in commands using the `@` prefix:
+
+```markdown
+# Reference a specific file
+Review the implementation in @src/utils/helpers.js
+
+# Reference multiple files
+Compare @src/old-version.js with @src/new-version.js
+```
+
+### Thinking Mode
+
+Slash commands can trigger extended thinking by including extended thinking keywords.
+
+## Frontmatter
+
+| Frontmatter | Purpose | Default |
+|-------------|---------|---------|
+| `allowed-tools` | List of tools the command can use | Inherits from conversation |
+| `argument-hint` | Arguments expected (shown in autocomplete) | None |
+| `description` | Brief description of the command | Uses first line from prompt |
+| `model` | Specific model string | Inherits from conversation |
+| `disable-model-invocation` | Prevent SlashCommand tool from calling this | false |
+
+Example:
+
+```yaml
+---
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*)
+argument-hint: [message]
+description: Create a git commit
+model: claude-3-5-haiku-20241022
+---
+
+Create a git commit with message: $ARGUMENTS
+```
+
+## Plugin Commands
+
+Plugins can provide custom slash commands that integrate seamlessly with Claude Code.
+
+**Location:** `commands/` directory in plugin root
+
+### Invocation Patterns
+
+- Direct: `/command-name`
+- Plugin-prefixed: `/plugin-name:command-name`
+- With arguments: `/command-name arg1 arg2`
+
+## Skills vs Slash Commands
+
+| Aspect | Slash Commands | Agent Skills |
+|--------|----------------|--------------|
+| Complexity | Simple prompts | Complex capabilities |
+| Structure | Single `.md` file | Directory with SKILL.md + resources |
+| Discovery | Explicit invocation (`/command`) | Automatic (based on context) |
+| Files | One file only | Multiple files, scripts, templates |
+
+**Use slash commands for:**
+- Quick, frequently used prompts
+- Simple prompt snippets
+- Frequently used instructions that fit in one file
+
+**Use Skills for:**
+- Complex workflows with multiple steps
+- Capabilities requiring scripts or utilities
+- Knowledge organized across multiple files


### PR DESCRIPTION
## Summary
- Adds `claude-code-slash-commands` skill for creating custom Claude Code commands
- Includes official Anthropic documentation (attributed) as reference
- Updates README with example prompts for all commands, skills, and agents