### PR TITLE
feat: add anthropic-evaluations skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ See [skill history examples](./docs/examples/skill-history).
 - Configures frontmatter (allowed-tools, argument-hint)
 - Supports `$ARGUMENTS` and positional `$1`, `$2` params
 
+#### `anthropic-evaluations`
+
+> Create an evaluation suite for my coding agent
+
+- Defines grader types (code-based, model-based, human)
+- Patterns for coding, conversational, research, and computer use agents
+- YAML templates for eval tasks
+- Roadmap for building evals from scratch
+
 ### Agents
 
 #### `researcher`

--- a/plugins/toolkit/skills/anthropic-evaluations/SKILL.md
+++ b/plugins/toolkit/skills/anthropic-evaluations/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: anthropic-evaluations
+description: This skill should be used when the user asks to "create evals", "evaluate an agent", "build evaluation suite", or mentions agent testing, graders, or benchmarks. Also suggest when building coding agents, conversational agents, or research agents that need quality assurance.
+---
+
+# Anthropic Evaluations
+
+Build rigorous evaluations for AI agents using Anthropic's proven patterns.
+
+## Quick Reference
+
+You MUST read the reference files for detailed guidance:
+
+- [Grader Types](./references/grader-types.md) - Code-based, model-based, human graders
+- [Agent Type Patterns](./references/agent-type-patterns.md) - Coding, conversational, research, computer use
+- [Roadmap](./references/roadmap.md) - Steps 0-8 for building evals from scratch
+- [Frameworks](./references/frameworks.md) - Harbor, Promptfoo, Braintrust, etc.
+
+**YAML Templates:**
+- [coding-agent-eval.yaml](./references/coding-agent-eval.yaml) - Coding agent template
+- [conversational-agent-eval.yaml](./references/conversational-agent-eval.yaml) - Support agent template
+
+**Annotated Examples:**
+- [Example: Coding Agent](./references/example-coding-agent.md) - Auth bypass fix walkthrough
+- [Example: Conversational](./references/example-conversational.md) - Refund handling walkthrough
+
+## Core Definitions
+
+| Term | Definition |
+|------|------------|
+| **Task** | Single test with defined inputs and success criteria |
+| **Trial** | One attempt at a task (run multiple for consistency) |
+| **Grader** | Logic that scores agent performance; tasks can have multiple |
+| **Transcript** | Complete record of a trial (outputs, tool calls, reasoning) |
+| **Outcome** | Final state in environment (not just what agent said) |
+| **Evaluation harness** | Infrastructure that runs evals end-to-end |
+| **Agent harness** | System enabling model to act as agent (scaffold) |
+| **Evaluation suite** | Collection of tasks measuring specific capabilities |
+
+## Grader Types (Quick Reference)
+
+| Type | Methods | Best For |
+|------|---------|----------|
+| **Code-based** | String match, unit tests, static analysis, state checks | Fast, cheap, objective verification |
+| **Model-based** | Rubric scoring, assertions, pairwise comparison | Nuanced, open-ended tasks |
+| **Human** | SME review, A/B testing, spot-check sampling | Gold standard calibration |
+
+See [Grader Types](./references/grader-types.md) for detailed comparison.
+
+## Capability vs Regression Evals
+
+| Type | Question | Target Pass Rate |
+|------|----------|------------------|
+| **Capability** | "What can this agent do well?" | Start low, hill-climb |
+| **Regression** | "Does it still handle what it used to?" | Near 100% |
+
+Capability evals with high pass rates "graduate" to regression suites.
+
+## Non-Determinism Metrics
+
+| Metric | Measures | Use When |
+|--------|----------|----------|
+| **pass@k** | At least 1 success in k attempts | One success matters (coding) |
+| **pass^k** | All k attempts succeed | Consistency essential (customer-facing) |
+
+Example: 75% per-trial success rate
+- pass@3 ≈ 98% (likely to get at least one)
+- pass^3 ≈ 42% (0.75³ all succeed)
+
+## Tracked Metrics
+
+```yaml
+tracked_metrics:
+  - type: transcript
+    metrics: [n_turns, n_toolcalls, n_total_tokens]
+  - type: latency
+    metrics: [time_to_first_token, output_tokens_per_sec, time_to_last_token]
+```
+
+## Attribution
+
+Based on [Demystifying evals for AI agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents) by Anthropic (January 2026).

--- a/plugins/toolkit/skills/anthropic-evaluations/references/agent-type-patterns.md
+++ b/plugins/toolkit/skills/anthropic-evaluations/references/agent-type-patterns.md
@@ -1,0 +1,116 @@
+# Agent Type Patterns
+
+Evaluation strategies for different agent types.
+
+## Coding Agents
+
+Write, test, and debug code. Navigate codebases and run commands.
+
+**Primary graders:**
+- Unit tests (deterministic, pass/fail)
+- LLM rubric for code quality
+
+**Key benchmarks:**
+- [SWE-bench Verified](https://www.swebench.com/SWE-bench/) - GitHub issues, test suites
+- [Terminal-Bench](https://www.tbench.ai/) - End-to-end technical tasks
+
+**Evaluation approach:**
+1. Well-specified tasks with clear success criteria
+2. Stable test environments
+3. Thorough tests for generated code
+4. Optional: heuristics-based code quality rules
+5. Optional: model-based graders for tool usage patterns
+
+**Example graders:**
+```yaml
+graders:
+  - type: deterministic_tests
+    required: [test_feature.py, test_edge_cases.py]
+  - type: llm_rubric
+    rubric: prompts/code_quality.md
+  - type: static_analysis
+    commands: [ruff, mypy, bandit]
+```
+
+## Conversational Agents
+
+Interact with users in support, sales, or coaching. Maintain state and take actions.
+
+**Primary graders:**
+- Model-based for communication quality
+- State checks for outcomes
+- Transcript constraints
+
+**Key benchmarks:**
+- [τ-Bench](https://arxiv.org/abs/2406.12045) - Multi-turn interactions
+- [τ2-Bench](https://arxiv.org/abs/2506.07982) - Retail, airline scenarios
+
+**Evaluation approach:**
+1. Verifiable end-state outcomes
+2. Rubrics for interaction quality
+3. Second LLM to simulate user
+4. Multidimensional success criteria
+
+**Example graders:**
+```yaml
+graders:
+  - type: llm_rubric
+    rubric: prompts/support_quality.md
+    assertions:
+      - "Agent showed empathy"
+      - "Resolution clearly explained"
+  - type: state_check
+    expect:
+      tickets: {status: resolved}
+  - type: transcript
+    max_turns: 10
+```
+
+## Research Agents
+
+Gather, synthesize, and analyze information. Produce reports or answers.
+
+**Primary graders:**
+- Groundedness checks (claims supported by sources)
+- Coverage checks (key facts included)
+- Source quality checks (authoritative sources)
+- Exact match for objective answers
+
+**Key benchmarks:**
+- [BrowseComp](http://arxiv.org/abs/2504.12516) - Finding needles in haystacks across the web
+
+**Evaluation approach:**
+1. Combine multiple grader types
+2. Frequent calibration against expert judgment
+3. LLM flags unsupported claims and gaps
+4. Verify synthesis coherence and completeness
+
+**Challenges:**
+- Experts may disagree on comprehensiveness
+- Ground truth shifts as content changes
+- Longer outputs = more room for mistakes
+
+## Computer Use Agents
+
+Interact through GUI (screenshots, clicks, keyboard) rather than APIs.
+
+**Primary graders:**
+- URL and page state checks
+- Backend state verification
+- File system inspection
+- Application config checks
+
+**Key benchmarks:**
+- [WebArena](https://arxiv.org/abs/2307.13854) - Browser-based tasks
+- [OSWorld](https://os-world.github.io/) - Full OS control
+
+**Evaluation approach:**
+1. Run agent in real or sandboxed environment
+2. Check intended outcome achieved
+3. Inspect diverse artifacts after completion
+4. Balance token efficiency vs latency
+
+**Token efficiency considerations:**
+- DOM-based: Fast execution, many tokens
+- Screenshot-based: Slower, more token-efficient
+- Choose based on task (text extraction vs visual navigation)

--- a/plugins/toolkit/skills/anthropic-evaluations/references/coding-agent-eval.yaml
+++ b/plugins/toolkit/skills/anthropic-evaluations/references/coding-agent-eval.yaml
@@ -1,0 +1,53 @@
+# Coding Agent Evaluation Template
+# Based on Anthropic's "Demystifying evals for AI agents"
+# https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents
+
+task:
+  id: "fix-auth-bypass_1"
+  desc: "Fix authentication bypass when password field is empty and ..."
+
+graders:
+  # Primary: Unit tests for correctness
+  - type: deterministic_tests
+    required:
+      - test_empty_pw_rejected.py
+      - test_null_pw_rejected.py
+
+  # Secondary: Code quality assessment
+  - type: llm_rubric
+    rubric: prompts/code_quality.md
+
+  # Tertiary: Static analysis
+  - type: static_analysis
+    commands:
+      - ruff    # Linting
+      - mypy    # Type checking
+      - bandit  # Security scanning
+
+  # Verify outcome in environment
+  - type: state_check
+    expect:
+      security_logs:
+        event_type: "auth_blocked"
+
+  # Optional: Verify tool usage (use sparingly)
+  - type: tool_calls
+    required:
+      - tool: read_file
+        params:
+          path: "src/auth/*"
+      - tool: edit_file
+      - tool: run_tests
+
+tracked_metrics:
+  - type: transcript
+    metrics:
+      - n_turns
+      - n_toolcalls
+      - n_total_tokens
+
+  - type: latency
+    metrics:
+      - time_to_first_token
+      - output_tokens_per_sec
+      - time_to_last_token

--- a/plugins/toolkit/skills/anthropic-evaluations/references/conversational-agent-eval.yaml
+++ b/plugins/toolkit/skills/anthropic-evaluations/references/conversational-agent-eval.yaml
@@ -1,0 +1,50 @@
+# Conversational Agent Evaluation Template
+# Based on Anthropic's "Demystifying evals for AI agents"
+# https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents
+
+task:
+  id: "support-refund_1"
+  desc: "Handle refund request from frustrated customer"
+
+graders:
+  # Primary: Communication quality and behavior
+  - type: llm_rubric
+    rubric: prompts/support_quality.md
+    assertions:
+      - "Agent showed empathy for customer's frustration"
+      - "Resolution was clearly explained"
+      - "Agent's response grounded in fetch_policy tool results"
+
+  # Verify actual outcomes in environment
+  - type: state_check
+    expect:
+      tickets:
+        status: resolved
+      refunds:
+        status: processed
+
+  # Verify required workflow steps
+  - type: tool_calls
+    required:
+      - tool: verify_identity
+      - tool: process_refund
+        params:
+          amount: "<=100"
+      - tool: send_confirmation
+
+  # Efficiency constraint
+  - type: transcript
+    max_turns: 10
+
+tracked_metrics:
+  - type: transcript
+    metrics:
+      - n_turns
+      - n_toolcalls
+      - n_total_tokens
+
+  - type: latency
+    metrics:
+      - time_to_first_token
+      - output_tokens_per_sec
+      - time_to_last_token

--- a/plugins/toolkit/skills/anthropic-evaluations/references/example-coding-agent.md
+++ b/plugins/toolkit/skills/anthropic-evaluations/references/example-coding-agent.md
@@ -1,0 +1,99 @@
+# Example: Coding Agent Evaluation
+
+Annotated walkthrough of a coding agent eval for fixing an authentication vulnerability.
+
+## Task Definition
+
+```yaml
+task:
+  id: "fix-auth-bypass_1"
+  desc: "Fix authentication bypass when password field is empty"
+```
+
+- **id**: Unique identifier for the task
+- **desc**: Clear description of what needs to be fixed
+
+## Graders
+
+### 1. Deterministic Tests
+
+```yaml
+- type: deterministic_tests
+  required: [test_empty_pw_rejected.py, test_null_pw_rejected.py]
+```
+
+Unit tests that must pass. Binary pass/fail - the core verification that the bug is fixed.
+
+### 2. LLM Rubric
+
+```yaml
+- type: llm_rubric
+  rubric: prompts/code_quality.md
+```
+
+Model-based grader evaluates code quality against a rubric. Catches issues tests might miss (readability, maintainability).
+
+### 3. Static Analysis
+
+```yaml
+- type: static_analysis
+  commands: [ruff, mypy, bandit]
+```
+
+Run linters and security scanners:
+- **ruff**: Python linting
+- **mypy**: Type checking
+- **bandit**: Security vulnerability scanning
+
+### 4. State Check
+
+```yaml
+- type: state_check
+  expect:
+    security_logs: {event_type: "auth_blocked"}
+```
+
+Verify the outcome in the environment - not just that tests pass, but that the security event was logged.
+
+### 5. Tool Calls Verification
+
+```yaml
+- type: tool_calls
+  required:
+    - {tool: read_file, params: {path: "src/auth/*"}}
+    - {tool: edit_file}
+    - {tool: run_tests}
+```
+
+Verify the agent used expected tools. Use sparingly - don't punish creative solutions.
+
+## Tracked Metrics
+
+```yaml
+tracked_metrics:
+  - type: transcript
+    metrics:
+      - n_turns
+      - n_toolcalls
+      - n_total_tokens
+  - type: latency
+    metrics:
+      - time_to_first_token
+      - output_tokens_per_sec
+      - time_to_last_token
+```
+
+Track efficiency metrics for optimization and regression detection.
+
+## Full Example
+
+See [coding-agent-eval.yaml](./coding-agent-eval.yaml) for the complete template.
+
+## Best Practices for Coding Evals
+
+1. **Unit tests are primary** - Clear pass/fail signal
+2. **Add LLM rubric for quality** - Beyond just "does it work"
+3. **Static analysis catches issues** - Security, types, style
+4. **State checks verify outcomes** - Not just agent's claims
+5. **Tool call checks are optional** - Don't be too rigid
+6. **Track metrics for baselines** - Latency, tokens, turns

--- a/plugins/toolkit/skills/anthropic-evaluations/references/example-conversational.md
+++ b/plugins/toolkit/skills/anthropic-evaluations/references/example-conversational.md
@@ -1,0 +1,108 @@
+# Example: Conversational Agent Evaluation
+
+Annotated walkthrough of a support agent eval for handling refunds.
+
+## Task Context
+
+A support agent must handle a refund for a frustrated customer. Success is multidimensional:
+- Is the ticket resolved? (state check)
+- Did it finish in <10 turns? (transcript constraint)
+- Was the tone appropriate? (LLM rubric)
+
+## Graders
+
+### 1. LLM Rubric
+
+```yaml
+- type: llm_rubric
+  rubric: prompts/support_quality.md
+  assertions:
+    - "Agent showed empathy for customer's frustration"
+    - "Resolution was clearly explained"
+    - "Agent's response grounded in fetch_policy tool results"
+```
+
+Natural language assertions evaluated by an LLM judge. Captures nuance that code can't.
+
+**Key assertions:**
+- **Empathy**: Emotional intelligence check
+- **Clarity**: Communication quality
+- **Grounding**: Used tools appropriately, didn't hallucinate policy
+
+### 2. State Check
+
+```yaml
+- type: state_check
+  expect:
+    tickets: {status: resolved}
+    refunds: {status: processed}
+```
+
+Verify actual outcomes in the environment:
+- Ticket marked resolved in system
+- Refund actually processed (not just promised)
+
+### 3. Tool Calls Verification
+
+```yaml
+- type: tool_calls
+  required:
+    - {tool: verify_identity}
+    - {tool: process_refund, params: {amount: "<=100"}}
+    - {tool: send_confirmation}
+```
+
+Verify required workflow steps:
+- Identity verified before refund
+- Refund within authorized limit
+- Confirmation sent to customer
+
+### 4. Transcript Constraints
+
+```yaml
+- type: transcript
+  max_turns: 10
+```
+
+Efficiency constraint - agent should resolve quickly, not drag out conversation.
+
+## Tracked Metrics
+
+```yaml
+tracked_metrics:
+  - type: transcript
+    metrics:
+      - n_turns
+      - n_toolcalls
+      - n_total_tokens
+  - type: latency
+    metrics:
+      - time_to_first_token
+      - output_tokens_per_sec
+      - time_to_last_token
+```
+
+## Simulated Users
+
+Conversational evals often require a second LLM to simulate the user:
+
+```yaml
+user_simulation:
+  persona: "Frustrated customer, purchased item 3 days ago, item arrived damaged"
+  style: "Initially upset, responds to empathy, wants quick resolution"
+```
+
+This tests how the agent handles realistic interactions.
+
+## Full Example
+
+See [conversational-agent-eval.yaml](./conversational-agent-eval.yaml) for the complete template.
+
+## Best Practices for Conversational Evals
+
+1. **Model-based graders are primary** - Many "correct" solutions
+2. **State checks verify real outcomes** - Not just conversation
+3. **Transcript constraints ensure efficiency** - Max turns
+4. **Use simulated users** - Second LLM with persona
+5. **Multi-dimensional success** - Task completion AND interaction quality
+6. **Calibrate with humans** - Ensure LLM judgments match expert opinion

--- a/plugins/toolkit/skills/anthropic-evaluations/references/frameworks.md
+++ b/plugins/toolkit/skills/anthropic-evaluations/references/frameworks.md
@@ -1,0 +1,95 @@
+# Evaluation Frameworks
+
+Open-source and commercial frameworks for implementing agent evaluations.
+
+## Harbor
+
+**Focus:** Running agents in containerized environments at scale.
+
+- Infrastructure for running trials across cloud providers
+- Standardized format for defining tasks and graders
+- Popular benchmarks (Terminal-Bench 2.0) ship through Harbor registry
+- Run established benchmarks alongside custom eval suites
+
+**Website:** [harborframework.com](https://harborframework.com/)
+
+## Promptfoo
+
+**Focus:** Lightweight, flexible, declarative configuration.
+
+- YAML configuration for prompt testing
+- Assertion types from string matching to LLM-as-judge
+- Open-source
+- Used by Anthropic for many product evals
+
+**Website:** [promptfoo.dev](https://www.promptfoo.dev/)
+
+## Braintrust
+
+**Focus:** Offline evaluation + production observability + experiment tracking.
+
+- Iterate during development AND monitor in production
+- `autoevals` library with pre-built scorers
+- Factuality, relevance, and other common dimensions
+
+**Website:** [braintrust.dev](https://www.braintrust.dev/)
+
+## LangSmith
+
+**Focus:** LangChain ecosystem integration.
+
+- Tracing
+- Offline and online evaluations
+- Dataset management
+- Tight LangChain integration
+
+**Website:** [docs.langchain.com/langsmith/evaluation](https://docs.langchain.com/langsmith/evaluation)
+
+## Langfuse
+
+**Focus:** Self-hosted open-source alternative.
+
+- Similar capabilities to LangSmith
+- Self-hosted for data residency requirements
+- Open-source
+
+**Website:** [langfuse.com](https://langfuse.com/)
+
+## Choosing a Framework
+
+| Need | Consider |
+|------|----------|
+| Containerized agents at scale | Harbor |
+| Lightweight YAML config | Promptfoo |
+| Dev + production monitoring | Braintrust |
+| LangChain ecosystem | LangSmith |
+| Self-hosted / data residency | Langfuse |
+
+## Framework vs Custom
+
+Many teams:
+- Combine multiple tools
+- Roll their own framework
+- Start with simple evaluation scripts
+
+**Key insight:** Frameworks are only as good as the eval tasks you run through them.
+
+**Recommendation:**
+1. Quickly pick a framework that fits your workflow
+2. Invest energy in the evals themselves
+3. Iterate on high-quality test cases and graders
+
+## Holistic Understanding
+
+Automated evals are one of many methods:
+
+| Method | Stage | Use |
+|--------|-------|-----|
+| Automated evals | Pre-launch, CI/CD | First line of defense |
+| Production monitoring | Post-launch | Detect drift, real-world failures |
+| A/B testing | Sufficient traffic | Validate significant changes |
+| User feedback | Ongoing | Fill gaps, surface unknowns |
+| Transcript review | Weekly | Build intuition, catch subtle issues |
+| Human studies | Periodic | Calibrate LLM graders |
+
+No single layer catches every issue. Combine methods like the Swiss Cheese Model from safety engineering.

--- a/plugins/toolkit/skills/anthropic-evaluations/references/grader-types.md
+++ b/plugins/toolkit/skills/anthropic-evaluations/references/grader-types.md
@@ -1,0 +1,101 @@
+# Grader Types
+
+Agent evaluations combine three types of graders. Choose the right graders for each task.
+
+## Code-Based Graders
+
+Fast, cheap, objective, reproducible.
+
+| Method | Description |
+|--------|-------------|
+| String match | Exact, regex, or fuzzy matching |
+| Binary tests | fail-to-pass, pass-to-pass |
+| Static analysis | Lint, type checking, security (ruff, mypy, bandit) |
+| Outcome verification | Check final state in environment |
+| Tool calls verification | Verify tools used and parameters |
+| Transcript analysis | Turns taken, token usage |
+
+**Strengths:**
+- Fast and cheap
+- Objective and reproducible
+- Easy to debug
+- Verify specific conditions
+
+**Weaknesses:**
+- Brittle to valid variations
+- Lacking in nuance
+- Limited for subjective tasks
+
+## Model-Based Graders
+
+Flexible, scalable, captures nuance.
+
+| Method | Description |
+|--------|-------------|
+| Rubric-based scoring | Grade against defined criteria |
+| Natural language assertions | "Agent showed empathy" |
+| Pairwise comparison | Compare two outputs |
+| Reference-based evaluation | Compare to gold standard |
+| Multi-judge consensus | Multiple LLMs vote |
+
+**Strengths:**
+- Flexible and scalable
+- Captures nuance
+- Handles open-ended tasks
+- Handles freeform output
+
+**Weaknesses:**
+- Non-deterministic
+- More expensive than code
+- Requires calibration with human graders
+
+## Human Graders
+
+Gold standard quality, matches expert judgment.
+
+| Method | Description |
+|--------|-------------|
+| SME review | Subject matter expert evaluation |
+| Crowdsourced judgment | Multiple human raters |
+| Spot-check sampling | Random sample review |
+| A/B testing | Compare variants with users |
+| Inter-annotator agreement | Measure rater consistency |
+
+**Strengths:**
+- Gold standard quality
+- Matches expert user judgment
+- Used to calibrate model-based graders
+
+**Weaknesses:**
+- Expensive and slow
+- Often requires access to human experts at scale
+
+## Scoring Strategies
+
+For each task, scoring can be:
+
+| Strategy | Description |
+|----------|-------------|
+| **Weighted** | Combined grader scores must hit threshold |
+| **Binary** | All graders must pass |
+| **Hybrid** | Mix of weighted and binary |
+
+## Best Practices
+
+1. **Choose deterministic graders where possible** - Code-based for clear pass/fail
+2. **Use LLM graders where necessary** - For nuance and flexibility
+3. **Use human graders judiciously** - For calibration and validation
+4. **Build in partial credit** - Represent continuum of success
+5. **Grade outcomes, not paths** - Don't punish creative solutions
+6. **Give LLM judges an "Unknown" option** - Avoid hallucinations
+
+## Calibrating Model-Based Graders
+
+LLM-as-judge graders should be closely calibrated with human experts:
+
+1. Create structured rubrics for each dimension
+2. Grade each dimension with isolated LLM judge
+3. Periodically compare with human grading
+4. Adjust prompts/rubrics when divergence detected
+
+Once robust, human review only needed occasionally.

--- a/plugins/toolkit/skills/anthropic-evaluations/references/roadmap.md
+++ b/plugins/toolkit/skills/anthropic-evaluations/references/roadmap.md
@@ -1,0 +1,123 @@
+# Roadmap: Zero to Great Evals
+
+Field-tested advice for going from no evals to evals you can trust.
+
+## Step 0: Start Early
+
+Don't wait for hundreds of tasks. Start with 20-50 simple tasks from real failures.
+
+**Why early:**
+- Early changes have large, noticeable effects
+- Small sample sizes suffice initially
+- Evals get harder to build the longer you wait
+- Product requirements naturally translate to test cases
+
+## Step 1: Start with Manual Checks
+
+Begin with behaviors you already verify manually:
+- Checks run before each release
+- Common tasks end users try
+- Bug tracker and support queue issues
+
+**Prioritize by user impact** - invest effort where it counts.
+
+## Step 2: Write Unambiguous Tasks
+
+A good task: two domain experts would independently reach the same pass/fail verdict.
+
+**Requirements:**
+- Task is passable by an agent following instructions correctly
+- Everything the grader checks is clear from task description
+- No failing due to ambiguous specs
+
+**Create reference solutions:**
+- Known-working output that passes all graders
+- Proves task is solvable
+- Verifies graders are correctly configured
+
+**Red flag:** 0% pass rate across many trials (0% pass@100) usually means broken task, not incapable agent.
+
+## Step 3: Build Balanced Problem Sets
+
+Test both where behavior SHOULD and SHOULDN'T occur.
+
+**Example - Web search:**
+- Queries where model should search (weather)
+- Queries where it should use existing knowledge (who founded Apple?)
+
+One-sided evals create one-sided optimization.
+
+## Step 4: Build Robust Eval Harness
+
+**Requirements:**
+- Agent in eval functions like production agent
+- Environment doesn't introduce noise
+- Each trial starts from clean environment
+- No shared state between runs (files, cache, resources)
+
+**Watch for:**
+- Correlated failures from infrastructure flakiness
+- Artificially inflated performance from shared state
+- Agent gaining unfair advantage (e.g., reading git history from previous trials)
+
+## Step 5: Design Graders Thoughtfully
+
+1. **Choose deterministic graders where possible**
+2. **Use LLM graders where necessary**
+3. **Use human graders for validation**
+
+**Principles:**
+- Grade what agent produced, not path it took
+- Build in partial credit for multi-component tasks
+- Give LLM judges "Unknown" option to avoid hallucinations
+- Create clear, structured rubrics per dimension
+- Make graders resistant to bypasses/hacks
+
+**Calibrate model graders:**
+- Compare with human experts
+- Adjust when divergence detected
+- Once robust, human review only occasionally
+
+## Step 6: Check the Transcripts
+
+You won't know if graders work without reading transcripts and grades.
+
+**What to look for:**
+- Did agent make genuine mistake or did grader reject valid solution?
+- Key details about agent and eval behavior
+- Failures should seem fair - clear what went wrong
+
+**Critical skill:** Reading transcripts verifies eval measures what matters.
+
+## Step 7: Monitor for Capability Eval Saturation
+
+**Eval saturation:** Agent passes all solvable tasks, no room for improvement.
+
+**Signs:**
+- Scores at or near 100%
+- Progress appears to slow
+- Large capability improvements show as small score increases
+
+**Response:**
+- Graduate saturated capability evals to regression suite
+- Develop new, harder capability evals
+- Don't take scores at face value - dig into details
+
+## Step 8: Maintain Long-Term
+
+An eval suite needs ongoing attention and clear ownership.
+
+**Effective approach:**
+- Dedicated evals team owns core infrastructure
+- Domain experts and product teams contribute tasks
+- Product teams run evaluations themselves
+
+**Eval-driven development:**
+1. Build evals to define planned capabilities
+2. Iterate until agent performs well
+3. When new model drops, run suite to see which bets paid off
+
+**Enable contribution:**
+- PMs, CSMs, salespeople can contribute eval tasks
+- Use Claude Code to submit PRs
+- People closest to users best positioned to define success


### PR DESCRIPTION
## Summary
- Add skill for building AI agent evaluations using Anthropic patterns
- Include grader types, agent-specific patterns, YAML templates
- Document roadmap for building evals from scratch

Based on: https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents