### PR TITLE
docs: add restart info to development skills

### DIFF
--- a/plugins/toolkit/skills/agent-development/SKILL.md
+++ b/plugins/toolkit/skills/agent-development/SKILL.md
@@ -37,3 +37,9 @@ color: purple
 ### Permission Denial Resilience
 
 Subagents continue after permission denial rather than stopping entirely. When a subagent hits a permissions wall, it tries alternative approaches automatically. This makes autonomous workflows more resilient and reduces the need for human intervention.
+
+## Important
+
+After creating or modifying agents, inform the user:
+
+> **No restart needed.** Agent changes take effect immediately - agents are hot-reloaded.

--- a/plugins/toolkit/skills/claude-code-hook-development/SKILL.md
+++ b/plugins/toolkit/skills/claude-code-hook-development/SKILL.md
@@ -111,6 +111,12 @@ fi
 exit 0
 ```
 
+## Important
+
+After creating or modifying hooks, inform the user:
+
+> **No restart needed.** Hook changes take effect immediately - Claude Code reads settings fresh on each tool invocation.
+
 ## Attribution
 
 Examples adapted from [Steve Kinney's Claude Code Hook Examples](https://stevekinney.com/courses/ai-development/claude-code-hook-examples).

--- a/plugins/toolkit/skills/claude-code-statusline-development/SKILL.md
+++ b/plugins/toolkit/skills/claude-code-statusline-development/SKILL.md
@@ -84,6 +84,12 @@ chmod +x ~/.claude/statusline.sh
 - Test with mock JSON: `echo '{"model":{"display_name":"Test"}}' | ./statusline.sh`
 - Cache expensive operations (git status) if needed
 
+## Important
+
+After creating or modifying statuslines, inform the user:
+
+> **No restart needed.** Statusline changes take effect immediately - Claude Code reads settings fresh on each update.
+
 ## Attribution
 
 Based on [Claude Code Status Line Configuration](https://code.claude.com/docs/en/statusline).

--- a/plugins/toolkit/skills/skill-development/SKILL.md
+++ b/plugins/toolkit/skills/skill-development/SKILL.md
@@ -86,9 +86,11 @@ See [api-reference.md](./references/api-reference.md)
 
 Claude loads reference files only when needed.
 
-## Hot Reload
+## Important
 
-Skills in `~/.claude/skills` or `.claude/skills` are hot-reloaded - changes take effect immediately without restarting Claude Code. This enables rapid iteration during development.
+After creating or modifying skills, inform the user:
+
+> **No restart needed.** Skill changes take effect immediately - skills are hot-reloaded.
 
 ## Checklist
 


### PR DESCRIPTION
## Summary
- Add Important section to hook, skill, agent, and statusline development skills
- Clarifies that no restart is needed - changes take effect immediately