### PR TITLE
fix: use lowercase for local variables in shell script examples

### DIFF
--- a/plugins/toolkit/skills/claude-code-statusline-development/SKILL.md
+++ b/plugins/toolkit/skills/claude-code-statusline-development/SKILL.md
@@ -61,14 +61,14 @@ See [JSON Schema](./references/json-schema.md) for complete structure.
 input=$(cat)
 
 # Extract values using jq
-MODEL=$(echo "$input" | jq -r '.model.display_name')
-DIR=$(echo "$input" | jq -r '.workspace.current_dir')
+model=$(echo "$input" | jq -r '.model.display_name')
+dir=$(echo "$input" | jq -r '.workspace.current_dir')
 
 # Colors via tput
 blue=$(tput setaf 4)
 reset=$(tput sgr0)
 
-echo "${blue}[$MODEL]${reset} ${DIR##*/}"
+echo "${blue}[$model]${reset} ${dir##*/}"
 ```
 
 Make executable:

--- a/plugins/toolkit/skills/claude-code-statusline-development/references/example-context-usage.md
+++ b/plugins/toolkit/skills/claude-code-statusline-development/references/example-context-usage.md
@@ -22,16 +22,16 @@ For accurate context percentage, use `current_usage`.
 #!/bin/bash
 input=$(cat)
 
-MODEL=$(echo "$input" | jq -r '.model.display_name')
-CONTEXT_SIZE=$(echo "$input" | jq -r '.context_window.context_window_size')
-USAGE=$(echo "$input" | jq '.context_window.current_usage')
+model=$(echo "$input" | jq -r '.model.display_name')
+context_size=$(echo "$input" | jq -r '.context_window.context_window_size')
+usage=$(echo "$input" | jq '.context_window.current_usage')
 
-if [ "$USAGE" != "null" ]; then
-    CURRENT_TOKENS=$(echo "$USAGE" | jq '.input_tokens + .cache_creation_input_tokens + .cache_read_input_tokens')
-    PERCENT=$((CURRENT_TOKENS * 100 / CONTEXT_SIZE))
-    echo "[$MODEL] Context: ${PERCENT}%"
+if [ "$usage" != "null" ]; then
+    current_tokens=$(echo "$usage" | jq '.input_tokens + .cache_creation_input_tokens + .cache_read_input_tokens')
+    percent=$((current_tokens * 100 / context_size))
+    echo "[$model] Context: ${percent}%"
 else
-    echo "[$MODEL] Context: 0%"
+    echo "[$model] Context: 0%"
 fi
 ```
 
@@ -49,9 +49,9 @@ Changes color based on usage level:
 #!/bin/bash
 input=$(cat)
 
-MODEL=$(echo "$input" | jq -r '.model.display_name')
-CONTEXT_SIZE=$(echo "$input" | jq -r '.context_window.context_window_size')
-USAGE=$(echo "$input" | jq '.context_window.current_usage')
+model=$(echo "$input" | jq -r '.model.display_name')
+context_size=$(echo "$input" | jq -r '.context_window.context_window_size')
+usage=$(echo "$input" | jq '.context_window.current_usage')
 
 # Colors
 green=$(tput setaf 2)
@@ -59,22 +59,22 @@ yellow=$(tput setaf 3)
 red=$(tput setaf 1)
 reset=$(tput sgr0)
 
-if [ "$USAGE" != "null" ]; then
-    CURRENT_TOKENS=$(echo "$USAGE" | jq '.input_tokens + .cache_creation_input_tokens + .cache_read_input_tokens')
-    PERCENT=$((CURRENT_TOKENS * 100 / CONTEXT_SIZE))
+if [ "$usage" != "null" ]; then
+    current_tokens=$(echo "$usage" | jq '.input_tokens + .cache_creation_input_tokens + .cache_read_input_tokens')
+    percent=$((current_tokens * 100 / context_size))
 
     # Color based on usage
-    if [ "$PERCENT" -lt 50 ]; then
-        COLOR=$green
-    elif [ "$PERCENT" -lt 80 ]; then
-        COLOR=$yellow
+    if [ "$percent" -lt 50 ]; then
+        color=$green
+    elif [ "$percent" -lt 80 ]; then
+        color=$yellow
     else
-        COLOR=$red
+        color=$red
     fi
 
-    echo "[$MODEL] ${COLOR}${PERCENT}%${reset}"
+    echo "[$model] ${color}${percent}%${reset}"
 else
-    echo "[$MODEL] ${green}0%${reset}"
+    echo "[$model] ${green}0%${reset}"
 fi
 ```
 
@@ -84,9 +84,9 @@ fi
 #!/bin/bash
 input=$(cat)
 
-MODEL=$(echo "$input" | jq -r '.model.display_name')
-CONTEXT_SIZE=$(echo "$input" | jq -r '.context_window.context_window_size')
-USAGE=$(echo "$input" | jq '.context_window.current_usage')
+model=$(echo "$input" | jq -r '.model.display_name')
+context_size=$(echo "$input" | jq -r '.context_window.context_window_size')
+usage=$(echo "$input" | jq '.context_window.current_usage')
 
 # Colors
 green=$(tput setaf 2)
@@ -95,29 +95,29 @@ red=$(tput setaf 1)
 dim=$(tput dim)
 reset=$(tput sgr0)
 
-PERCENT=0
-if [ "$USAGE" != "null" ]; then
-    CURRENT_TOKENS=$(echo "$USAGE" | jq '.input_tokens + .cache_creation_input_tokens + .cache_read_input_tokens')
-    PERCENT=$((CURRENT_TOKENS * 100 / CONTEXT_SIZE))
+percent=0
+if [ "$usage" != "null" ]; then
+    current_tokens=$(echo "$usage" | jq '.input_tokens + .cache_creation_input_tokens + .cache_read_input_tokens')
+    percent=$((current_tokens * 100 / context_size))
 fi
 
 # Build progress bar (10 chars wide)
-BAR_WIDTH=10
-FILLED=$((PERCENT * BAR_WIDTH / 100))
-EMPTY=$((BAR_WIDTH - FILLED))
+bar_width=10
+filled=$((percent * bar_width / 100))
+empty=$((bar_width - filled))
 
 # Color based on usage
-if [ "$PERCENT" -lt 50 ]; then
-    COLOR=$green
-elif [ "$PERCENT" -lt 80 ]; then
-    COLOR=$yellow
+if [ "$percent" -lt 50 ]; then
+    color=$green
+elif [ "$percent" -lt 80 ]; then
+    color=$yellow
 else
-    COLOR=$red
+    color=$red
 fi
 
-BAR="${COLOR}$(printf '█%.0s' $(seq 1 $FILLED 2>/dev/null))${dim}$(printf '░%.0s' $(seq 1 $EMPTY 2>/dev/null))${reset}"
+bar="${color}$(printf '█%.0s' $(seq 1 $filled 2>/dev/null))${dim}$(printf '░%.0s' $(seq 1 $empty 2>/dev/null))${reset}"
 
-echo "[$MODEL] $BAR ${PERCENT}%"
+echo "[$model] $bar ${percent}%"
 ```
 
 ## Output
@@ -132,19 +132,19 @@ echo "[$MODEL] $BAR ${PERCENT}%"
 #!/bin/bash
 input=$(cat)
 
-MODEL=$(echo "$input" | jq -r '.model.display_name')
-CONTEXT_SIZE=$(echo "$input" | jq -r '.context_window.context_window_size')
-USAGE=$(echo "$input" | jq '.context_window.current_usage')
+model=$(echo "$input" | jq -r '.model.display_name')
+context_size=$(echo "$input" | jq -r '.context_window.context_window_size')
+usage=$(echo "$input" | jq '.context_window.current_usage')
 
-if [ "$USAGE" != "null" ]; then
-    CURRENT=$(echo "$USAGE" | jq '.input_tokens + .cache_creation_input_tokens + .cache_read_input_tokens')
+if [ "$usage" != "null" ]; then
+    current=$(echo "$usage" | jq '.input_tokens + .cache_creation_input_tokens + .cache_read_input_tokens')
     # Format as K (thousands)
-    CURRENT_K=$((CURRENT / 1000))
-    SIZE_K=$((CONTEXT_SIZE / 1000))
-    echo "[$MODEL] ${CURRENT_K}K/${SIZE_K}K tokens"
+    current_k=$((current / 1000))
+    size_k=$((context_size / 1000))
+    echo "[$model] ${current_k}K/${size_k}K tokens"
 else
-    SIZE_K=$((CONTEXT_SIZE / 1000))
-    echo "[$MODEL] 0/${SIZE_K}K tokens"
+    size_k=$((context_size / 1000))
+    echo "[$model] 0/${size_k}K tokens"
 fi
 ```
 

--- a/plugins/toolkit/skills/claude-code-statusline-development/references/example-cost-tracking.md
+++ b/plugins/toolkit/skills/claude-code-statusline-development/references/example-cost-tracking.md
@@ -10,13 +10,13 @@ Display session costs, duration, and code changes.
 #!/bin/bash
 input=$(cat)
 
-MODEL=$(echo "$input" | jq -r '.model.display_name')
-COST=$(echo "$input" | jq -r '.cost.total_cost_usd')
+model=$(echo "$input" | jq -r '.model.display_name')
+cost=$(echo "$input" | jq -r '.cost.total_cost_usd')
 
 # Format cost to 4 decimal places
-COST_FMT=$(printf "%.4f" "$COST")
+cost_fmt=$(printf "%.4f" "$cost")
 
-echo "[$MODEL] \$${COST_FMT}"
+echo "[$model] \$${cost_fmt}"
 ```
 
 ## Output
@@ -31,16 +31,16 @@ echo "[$MODEL] \$${COST_FMT}"
 #!/bin/bash
 input=$(cat)
 
-MODEL=$(echo "$input" | jq -r '.model.display_name')
-ADDED=$(echo "$input" | jq -r '.cost.total_lines_added')
-REMOVED=$(echo "$input" | jq -r '.cost.total_lines_removed')
+model=$(echo "$input" | jq -r '.model.display_name')
+added=$(echo "$input" | jq -r '.cost.total_lines_added')
+removed=$(echo "$input" | jq -r '.cost.total_lines_removed')
 
 # Colors
 green=$(tput setaf 2)
 red=$(tput setaf 1)
 reset=$(tput sgr0)
 
-echo "[$MODEL] ${green}+${ADDED}${reset} ${red}-${REMOVED}${reset}"
+echo "[$model] ${green}+${added}${reset} ${red}-${removed}${reset}"
 ```
 
 ## Output
@@ -55,11 +55,11 @@ echo "[$MODEL] ${green}+${ADDED}${reset} ${red}-${REMOVED}${reset}"
 #!/bin/bash
 input=$(cat)
 
-MODEL=$(echo "$input" | jq -r '.model.display_name')
-COST=$(echo "$input" | jq -r '.cost.total_cost_usd')
-DURATION=$(echo "$input" | jq -r '.cost.total_duration_ms')
-ADDED=$(echo "$input" | jq -r '.cost.total_lines_added')
-REMOVED=$(echo "$input" | jq -r '.cost.total_lines_removed')
+model=$(echo "$input" | jq -r '.model.display_name')
+cost=$(echo "$input" | jq -r '.cost.total_cost_usd')
+duration=$(echo "$input" | jq -r '.cost.total_duration_ms')
+added=$(echo "$input" | jq -r '.cost.total_lines_added')
+removed=$(echo "$input" | jq -r '.cost.total_lines_removed')
 
 # Colors
 green=$(tput setaf 2)
@@ -68,15 +68,15 @@ dim=$(tput dim)
 reset=$(tput sgr0)
 
 # Format cost
-COST_FMT=$(printf "%.3f" "$COST")
+cost_fmt=$(printf "%.3f" "$cost")
 
 # Format duration as minutes:seconds
-DURATION_SEC=$((DURATION / 1000))
-MINS=$((DURATION_SEC / 60))
-SECS=$((DURATION_SEC % 60))
-TIME_FMT=$(printf "%d:%02d" "$MINS" "$SECS")
+duration_sec=$((duration / 1000))
+mins=$((duration_sec / 60))
+secs=$((duration_sec % 60))
+time_fmt=$(printf "%d:%02d" "$mins" "$secs")
 
-echo "[$MODEL] \$${COST_FMT} ${dim}${TIME_FMT}${reset} ${green}+${ADDED}${reset}/${red}-${REMOVED}${reset}"
+echo "[$model] \$${cost_fmt} ${dim}${time_fmt}${reset} ${green}+${added}${reset}/${red}-${removed}${reset}"
 ```
 
 ## Output
@@ -91,19 +91,19 @@ echo "[$MODEL] \$${COST_FMT} ${dim}${TIME_FMT}${reset} ${green}+${ADDED}${reset}
 #!/bin/bash
 input=$(cat)
 
-MODEL=$(echo "$input" | jq -r '.model.display_name')
-COST=$(echo "$input" | jq -r '.cost.total_cost_usd')
-DURATION=$(echo "$input" | jq -r '.cost.total_duration_ms')
+model=$(echo "$input" | jq -r '.model.display_name')
+cost=$(echo "$input" | jq -r '.cost.total_cost_usd')
+duration=$(echo "$input" | jq -r '.cost.total_duration_ms')
 
-COST_FMT=$(printf "%.3f" "$COST")
+cost_fmt=$(printf "%.3f" "$cost")
 
 # Calculate cost per minute
-if [ "$DURATION" -gt 0 ]; then
-    RATE=$(echo "scale=4; $COST / ($DURATION / 60000)" | bc)
-    RATE_FMT=$(printf "%.3f" "$RATE")
-    echo "[$MODEL] \$${COST_FMT} (\$${RATE_FMT}/min)"
+if [ "$duration" -gt 0 ]; then
+    rate=$(echo "scale=4; $cost / ($duration / 60000)" | bc)
+    rate_fmt=$(printf "%.3f" "$rate")
+    echo "[$model] \$${cost_fmt} (\$${rate_fmt}/min)"
 else
-    echo "[$MODEL] \$${COST_FMT}"
+    echo "[$model] \$${cost_fmt}"
 fi
 ```
 
@@ -119,10 +119,10 @@ fi
 #!/bin/bash
 input=$(cat)
 
-MODEL=$(echo "$input" | jq -r '.model.display_name')
-COST=$(echo "$input" | jq -r '.cost.total_cost_usd')
-CONTEXT_SIZE=$(echo "$input" | jq -r '.context_window.context_window_size')
-USAGE=$(echo "$input" | jq '.context_window.current_usage')
+model=$(echo "$input" | jq -r '.model.display_name')
+cost=$(echo "$input" | jq -r '.cost.total_cost_usd')
+context_size=$(echo "$input" | jq -r '.context_window.context_window_size')
+usage=$(echo "$input" | jq '.context_window.current_usage')
 
 # Colors
 green=$(tput setaf 2)
@@ -131,24 +131,24 @@ red=$(tput setaf 1)
 dim=$(tput dim)
 reset=$(tput sgr0)
 
-COST_FMT=$(printf "%.3f" "$COST")
+cost_fmt=$(printf "%.3f" "$cost")
 
-PERCENT=0
-if [ "$USAGE" != "null" ]; then
-    CURRENT=$(echo "$USAGE" | jq '.input_tokens + .cache_creation_input_tokens + .cache_read_input_tokens')
-    PERCENT=$((CURRENT * 100 / CONTEXT_SIZE))
+percent=0
+if [ "$usage" != "null" ]; then
+    current=$(echo "$usage" | jq '.input_tokens + .cache_creation_input_tokens + .cache_read_input_tokens')
+    percent=$((current * 100 / context_size))
 fi
 
 # Color context based on usage
-if [ "$PERCENT" -lt 50 ]; then
-    CTX_COLOR=$green
-elif [ "$PERCENT" -lt 80 ]; then
-    CTX_COLOR=$yellow
+if [ "$percent" -lt 50 ]; then
+    ctx_color=$green
+elif [ "$percent" -lt 80 ]; then
+    ctx_color=$yellow
 else
-    CTX_COLOR=$red
+    ctx_color=$red
 fi
 
-echo "[$MODEL] \$${COST_FMT} ${dim}|${reset} ${CTX_COLOR}${PERCENT}%${reset}"
+echo "[$model] \$${cost_fmt} ${dim}|${reset} ${ctx_color}${percent}%${reset}"
 ```
 
 ## Output

--- a/plugins/toolkit/skills/claude-code-statusline-development/references/example-git-aware.md
+++ b/plugins/toolkit/skills/claude-code-statusline-development/references/example-git-aware.md
@@ -10,19 +10,19 @@ Displays current directory and git branch when inside a repository.
 #!/bin/bash
 input=$(cat)
 
-MODEL=$(echo "$input" | jq -r '.model.display_name')
-CURRENT_DIR=$(echo "$input" | jq -r '.workspace.current_dir')
+model=$(echo "$input" | jq -r '.model.display_name')
+current_dir=$(echo "$input" | jq -r '.workspace.current_dir')
 
 # Get git branch if in a repo
-GIT_BRANCH=""
-if cd "$CURRENT_DIR" 2>/dev/null && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-    BRANCH=$(git branch --show-current 2>/dev/null)
-    if [ -n "$BRANCH" ]; then
-        GIT_BRANCH=" | $BRANCH"
+git_branch=""
+if cd "$current_dir" 2>/dev/null && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    branch=$(git branch --show-current 2>/dev/null)
+    if [ -n "$branch" ]; then
+        git_branch=" | $branch"
     fi
 fi
 
-echo "[$MODEL] ${CURRENT_DIR##*/}$GIT_BRANCH"
+echo "[$model] ${current_dir##*/}$git_branch"
 ```
 
 ## Output
@@ -39,7 +39,7 @@ Based on dwmkerr's dotfiles statusline:
 #!/bin/bash
 input=$(cat)
 
-CURRENT_DIR=$(echo "$input" | jq -r '.workspace.current_dir')
+current_dir=$(echo "$input" | jq -r '.workspace.current_dir')
 
 # Colors
 blue=$(tput setaf 4)
@@ -49,11 +49,11 @@ dim=$(tput dim)
 reset=$(tput sgr0)
 
 # Truncate path to last 3 folders, replace $HOME with ~
-pwd_display=$(echo "${CURRENT_DIR/#$HOME/~}" | rev | cut -d'/' -f1-3 | rev)
+pwd_display=$(echo "${current_dir/#$HOME/~}" | rev | cut -d'/' -f1-3 | rev)
 
 # Get git branch
 git_info=""
-if cd "$CURRENT_DIR" 2>/dev/null && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+if cd "$current_dir" 2>/dev/null && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     branch=$(git branch --show-current 2>/dev/null)
     if [ -n "$branch" ]; then
         git_info=" ${green}${branch}${reset}"
@@ -75,7 +75,7 @@ echo "${bold}${blue}${pwd_display}${reset}${git_info} ${dim}? for help${reset}"
 #!/bin/bash
 input=$(cat)
 
-CURRENT_DIR=$(echo "$input" | jq -r '.workspace.current_dir')
+current_dir=$(echo "$input" | jq -r '.workspace.current_dir')
 
 # Colors
 green=$(tput setaf 2)
@@ -83,7 +83,7 @@ yellow=$(tput setaf 3)
 reset=$(tput sgr0)
 
 git_info=""
-if cd "$CURRENT_DIR" 2>/dev/null && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+if cd "$current_dir" 2>/dev/null && git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     branch=$(git branch --show-current 2>/dev/null)
     if [ -n "$branch" ]; then
         # Check for uncommitted changes
@@ -95,7 +95,7 @@ if cd "$CURRENT_DIR" 2>/dev/null && git rev-parse --is-inside-work-tree >/dev/nu
     fi
 fi
 
-echo "${CURRENT_DIR##*/}${git_info}"
+echo "${current_dir##*/}${git_info}"
 ```
 
 ## Output

--- a/plugins/toolkit/skills/claude-code-statusline-development/references/example-simple.md
+++ b/plugins/toolkit/skills/claude-code-statusline-development/references/example-simple.md
@@ -10,10 +10,10 @@ A minimal statusline showing model name and current directory.
 #!/bin/bash
 input=$(cat)
 
-MODEL=$(echo "$input" | jq -r '.model.display_name')
-DIR=$(echo "$input" | jq -r '.workspace.current_dir')
+model=$(echo "$input" | jq -r '.model.display_name')
+dir=$(echo "$input" | jq -r '.workspace.current_dir')
 
-echo "[$MODEL] ${DIR##*/}"
+echo "[$model] ${dir##*/}"
 ```
 
 ## Output
@@ -28,15 +28,15 @@ echo "[$MODEL] ${DIR##*/}"
 #!/bin/bash
 input=$(cat)
 
-MODEL=$(echo "$input" | jq -r '.model.display_name')
-DIR=$(echo "$input" | jq -r '.workspace.current_dir')
+model=$(echo "$input" | jq -r '.model.display_name')
+dir=$(echo "$input" | jq -r '.workspace.current_dir')
 
 # Colors
 blue=$(tput setaf 4)
 bold=$(tput bold)
 reset=$(tput sgr0)
 
-echo "${bold}${blue}[$MODEL]${reset} ${DIR##*/}"
+echo "${bold}${blue}[$model]${reset} ${dir##*/}"
 ```
 
 ## Python Version

--- a/plugins/toolkit/skills/shell-script-development/SKILL.md
+++ b/plugins/toolkit/skills/shell-script-development/SKILL.md
@@ -32,6 +32,8 @@ echo -e "${green}✔${nc} completed successfully"
 |---------|------------|
 | Shebang | `#!/usr/bin/env bash` |
 | Safety | `set -e -o pipefail` |
+| Local variables | Lowercase (`model`, `dir`, `count`) |
+| Environment variables | Uppercase (`PATH`, `HOME`, `USER`) |
 | Color variables | Lowercase (`green`, `red`, `nc`) |
 | Status words | Lowercase (`error`, `warning`, `note`) |
 


### PR DESCRIPTION
## Summary
- Document variable naming convention in shell-script-development skill (lowercase for local vars, uppercase for env vars)
- Fix statusline skill template to use lowercase local variables
- Update all statusline example files to follow the convention