### PR TITLE
docs: add permissions section for script execution in commands

### DIFF
--- a/plugins/toolkit/skills/claude-code-plugin-development/SKILL.md
+++ b/plugins/toolkit/skills/claude-code-plugin-development/SKILL.md
@@ -92,6 +92,33 @@ claude plugin uninstall <plugin>
 claude --debug
 ```
 
+## Permissions
+
+**Problem:** Using `!` backticks to run plugin scripts fails with permission error:
+
+```
+Error: Bash command permission check failed for pattern
+"!`${CLAUDE_PLUGIN_ROOT}/scripts/my-script.sh 2>&1 || true`":
+This Bash command contains multiple operations.
+```
+
+**Cause:** `!` backticks have their own permission model separate from `allowed-tools`. Complex commands or scripts fail.
+
+**Solution:** Use the Bash tool instead of `!` backticks for scripts:
+
+```yaml
+---
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/scripts/my-script.sh:*)
+---
+
+Run the script:
+    ```bash
+    ${CLAUDE_PLUGIN_ROOT}/scripts/my-script.sh
+    ```
+```
+
+Simple git commands still work with `!` backticks: `!`git branch --show-current``
+
 ## Common Issues
 
 **Plugin installed but commands don't appear?**


### PR DESCRIPTION
## Summary
- Document the `!` backticks permission issue when running plugin scripts
- Explain workaround: use Bash tool with `allowed-tools` instead