### PR TITLE
feat: add project-setup skill for new GitHub repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ If commands don't appear, enable and restart:
 - [The `dwmkerr` Plugin](#the-dwmkerr-plugin)
     - [Skills](#skills-1)
         - [`my-repos`](#my-repos)
+        - [`project-setup`](#project-setup)
 - [Developer Guide](#developer-guide)
     - [Local Development](#local-development)
 - [Further Reading](#further-reading)
@@ -208,6 +209,15 @@ Personal plugin for dwmkerr-specific workflows.
 - Checks local first, stashes changes if needed for branch switching
 - Uses `gh` CLI to find remote repos if not local
 - Clones missing repos to the standard location
+
+#### `project-setup`
+
+> Create a new project called config-validator
+
+- Creates private GitHub repo with description
+- Configures squash merges only, branch protection
+- Enables GitHub Actions to create PRs
+- Adds MIT license and basic README
 
 ## Developer Guide
 

--- a/plugins/dwmkerr/skills/project-setup/SKILL.md
+++ b/plugins/dwmkerr/skills/project-setup/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: project-setup
+description: Create a new GitHub project with standard configuration. Use when user asks to "create a project", "set up a new repo", "initialize a repository", or wants to start a new GitHub project.
+---
+
+# Project Setup
+
+Create a new GitHub repository with standard dwmkerr project configuration.
+
+## What Gets Created
+
+1. **Private GitHub repo** with description
+2. **Branch protection** - prevent direct push to main
+3. **Squash merges only** for pull requests
+4. **Actions can create PRs** enabled
+5. **MIT License**
+6. **Basic README** with intro and quickstart
+
+## Setup Process
+
+### 1. Create the Repository
+
+```bash
+gh repo create <repo-name> \
+  --private \
+  --description "<short description>" \
+  --clone
+```
+
+### 2. Configure Repository Settings
+
+```bash
+# Require squash merges only, disable merge commits and rebase
+gh api repos/dwmkerr/<repo-name> \
+  --method PATCH \
+  --field allow_squash_merge=true \
+  --field allow_merge_commit=false \
+  --field allow_rebase_merge=false \
+  --field delete_branch_on_merge=true
+
+# Allow GitHub Actions to create PRs
+gh api repos/dwmkerr/<repo-name> \
+  --method PATCH \
+  --field allow_auto_merge=true
+
+gh api repos/dwmkerr/<repo-name>/actions/permissions/workflow \
+  --method PUT \
+  --field can_approve_pull_request_reviews=true \
+  --field default_workflow_permissions=write
+```
+
+### 3. Set Up Branch Protection
+
+```bash
+gh api repos/dwmkerr/<repo-name>/branches/main/protection \
+  --method PUT \
+  --field "required_pull_request_reviews[dismiss_stale_reviews]=false" \
+  --field "required_pull_request_reviews[require_code_owner_reviews]=false" \
+  --field "required_pull_request_reviews[required_approving_review_count]=0" \
+  --field "enforce_admins=false" \
+  --field "required_linear_history=true" \
+  --field "allow_force_pushes=false" \
+  --field "allow_deletions=false" \
+  --field "restrictions=null"
+```
+
+### 4. Create MIT License
+
+Create `LICENSE` file:
+
+```
+MIT License
+
+Copyright (c) 2025 Dave Kerr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+### 5. Create README
+
+Follow this pattern:
+
+```markdown
+# <repo-name>
+
+<One-line description of what this project does.>
+
+## Quickstart
+
+<Minimal steps to get started - install and run.>
+```
+
+Example:
+
+```markdown
+# my-awesome-tool
+
+CLI tool for automating deployment workflows.
+
+## Quickstart
+
+Install and run:
+
+\`\`\`bash
+npm install -g my-awesome-tool
+my-awesome-tool init
+\`\`\`
+```
+
+### 6. Initial Commit
+
+```bash
+git add LICENSE README.md
+git commit -m "chore: initial project setup"
+git push -u origin main
+```
+
+## Example Usage
+
+User: "Create a new project called 'config-validator' for validating YAML configs"
+
+1. `gh repo create config-validator --private --description "CLI tool for validating YAML configuration files" --clone`
+2. Configure squash merges and branch protection
+3. Create LICENSE and README
+4. Push initial commit


### PR DESCRIPTION
## Summary
- Add `project-setup` skill to dwmkerr plugin
- Creates private repos with standard config (squash merges, branch protection, Actions permissions)
- Includes MIT license and README template