### PR TITLE
docs: add skill tests badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # claude-toolkit
 
+[![Skill Tests](https://img.shields.io/github/actions/workflow/status/dwmkerr/claude-toolkit/skill-tests.yaml?label=skill%20tests)](https://github.com/dwmkerr/claude-toolkit/actions/workflows/skill-tests.yaml)
+
 General purpose Claude Code `toolkit` plugin for skill/hook/agent development, research, skill analysis, Github quality of life and more.
 
 ## Quickstart


### PR DESCRIPTION
## Summary
- Adds a shields.io badge showing skill test workflow status

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ❌ 3 failed — [View all](https://hub.continue.dev/inbox/pr/dwmkerr/claude-toolkit/36?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->