### PR TITLE
refactor: rename research skill to deep-research

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,13 @@ And when it does. The browser opens automatically:
 
 #### `research`
 
-> Research options for implementing OAuth in a Node.js app
+> Use the research skill to investigate options for implementing OAuth in a Node.js app
 
 - Searches web and clones GitHub repos
 - Requires 2-3 sources before recommending
 - Saves findings to `./scratch/research/`
+
+**Tip:** "research" is a generic term — Claude may use built-in tools (Explore, WebFetch) instead of this skill. Be explicit: say "use the research skill" or "use the researcher agent" to ensure the structured research workflow is triggered.
 
 #### `claude-code-hook-development`
 

--- a/plugins/toolkit/skills/research/SKILL.md
+++ b/plugins/toolkit/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: Research technical solutions by searching the web, examining GitHub repos, and gathering evidence. Use when exploring implementation options or evaluating technologies.
+description: Deep research into technical solutions by searching the web, examining GitHub repos, and gathering evidence. Use when the user explicitly says "use the research skill", "use a research agent", or asks for deep/thorough research into implementation options or technologies.
 ---
 
 # Research

--- a/plugins/toolkit/skills/research/skill-tests.yaml
+++ b/plugins/toolkit/skills/research/skill-tests.yaml
@@ -1,13 +1,18 @@
+# Tests that the research skill is invoked when explicitly requested
+# and skipped for direct implementation tasks. Note: "research" is a
+# generic term — Claude may use built-in tools (Explore, WebFetch)
+# instead unless the user explicitly says "use the research skill"
+# or "use the researcher agent".
 skill: toolkit:research
 model: haiku
 
 tests:
   - id: research-topic
-    prompt: "research how to implement OAuth2 with PKCE"
+    prompt: "use the research skill to investigate OAuth2 with PKCE implementation options"
     should_trigger: true
 
   - id: investigate-library
-    prompt: "research the differences between Vite and Webpack"
+    prompt: "use the research skill to compare Vite and Webpack"
     should_trigger: true
 
   - id: unrelated-fix


### PR DESCRIPTION
## Summary
- Rename `research` skill to `deep-research` for clearer routing signal
- Update researcher agent to reference `deep-research` skill
- Update skill tests with `deep-research` prompts
- Update CI matrix for renamed path