### PR TITLE
docs: add useful links to learn-and-improve skill

### DIFF
--- a/plugins/toolkit/skills/learn-and-improve/SKILL.md
+++ b/plugins/toolkit/skills/learn-and-improve/SKILL.md
@@ -139,6 +139,6 @@ For the full catalog of improvement types and examples, see:
 - [Improvement Types](./references/improvement-types.md) — all configuration levers with examples
 - [Diagnostic Checklist](./references/diagnostic-checklist.md) — systematic investigation steps
 
-## Useful Links
+## References
 
 - [agents.md outperforms skills in agent evals](https://vercel.com/blog/agents-md-outperforms-skills-in-our-agent-evals) — Vercel research showing that CLAUDE.md-style agent instructions outperform skill-based routing in evaluations

--- a/plugins/toolkit/skills/learn-and-improve/SKILL.md
+++ b/plugins/toolkit/skills/learn-and-improve/SKILL.md
@@ -138,3 +138,7 @@ If the log grows beyond ~30 entries, consolidate repeated patterns into the root
 For the full catalog of improvement types and examples, see:
 - [Improvement Types](./references/improvement-types.md) — all configuration levers with examples
 - [Diagnostic Checklist](./references/diagnostic-checklist.md) — systematic investigation steps
+
+## Useful Links
+
+- [agents.md outperforms skills in agent evals](https://vercel.com/blog/agents-md-outperforms-skills-in-our-agent-evals) — Vercel research showing that CLAUDE.md-style agent instructions outperform skill-based routing in evaluations


### PR DESCRIPTION
Adds a "Useful Links" section to the learn-and-improve skill with the Vercel blog post about agents.md outperforming skills in agent evals.

Closes #52

Generated with [Claude Code](https://claude.ai/code)

@claude this is actually useful link for the skill itself (or maybe 'references')