### PR TITLE
feat(slides): add conference hand-built HTML deck mode

### DIFF
--- a/plugins/dwmkerr/skills/slides/SKILL.md
+++ b/plugins/dwmkerr/skills/slides/SKILL.md
@@ -1,13 +1,24 @@
 ---
 name: slides
-description: Create and manage Slidev presentation decks. Use when user asks to "create slides", "make a presentation", "add slides to this project", "set up a slide deck", or mentions "slidev", "pitch deck", or "slides folder".
+description: Create and manage presentation decks. Two modes - Slidev markdown (default) and "conference" hand-built HTML. Use when user asks to "create slides", "make a presentation", "add slides to this project", "set up a slide deck", or mentions "slidev", "pitch deck", "conference talk", "conference deck", or "slides folder".
 ---
 
 # Slides
 
-Scaffold and manage Slidev markdown slide decks in any project.
+Scaffold and manage presentation decks in any project. Two modes:
 
-## Setup Flow
+- **Slidev mode (default)** - Markdown-driven decks using `@slidev/cli`. Best for project pitches, internal decks, README-driven content, and anything where the author edits markdown and lets Slidev render. Covered in the "Slidev Mode" section below.
+- **Conference mode** - Hand-built HTML deck modelled on the AI Native DevCon London 2026 talk. Dark theme, Inter + JetBrains Mono, right-arrow progressive reveal, fullscreen, page number, in-deck notes overlay, separate teleprompter sheet for a phone, deployable to GitHub Pages via a `gh-pages` worktree. No framework, no build step - the author edits HTML directly. Covered in the "Conference Mode" section further below.
+
+## 0. Ask which mode
+
+When the user invokes the skill, ASK upfront:
+
+> "Slidev (default) or conference (hand-built HTML)?"
+
+Pick by signal too. Default to **Slidev** unless the user says any of: "conference", "conference talk", "conference deck", "hand-built", "no framework", "html deck", or references the AI Native DevCon style. If they pick conference, skip the Slidev sections and follow "Conference Mode" below.
+
+## Slidev Mode
 
 ### 1. Ask where to keep slides
 
@@ -224,13 +235,91 @@ title: "Deck Title"
 
 **Utility classes**: `.qb-blue`, `.qb-navy`, `.qb-bg-dark`, `.qb-bg-light`, `.qb-accent-bar`
 
+## Conference Mode
+
+A hand-built HTML conference deck. **No framework, no Vue, no Slidev, no build step.** The author edits `presentation.html` directly. Speaker notes live in `presentation.md` and are baked into a standalone `notes.html` teleprompter sheet for a phone or second screen.
+
+### When to use it
+
+- A conference talk (20-45 minutes) where presence and feel matter as much as content.
+- Dark theme, typographic, whitespace-led, minimal chrome.
+- Custom interactions (right-arrow progressive reveal, hidden in-deck notes overlay, fullscreen toggle).
+- Deploys to GitHub Pages via a `gh-pages` worktree, with separate public URLs for the deck and for the phone-readable notes sheet.
+
+If the user wants a quick scaffold from a README, or wants Markdown-driven content with Slidev's built-in layouts, use **Slidev mode** instead.
+
+### Setup flow
+
+1. Ask where to keep the deck. Suggest `./presentation` or a conference-specific folder name (for example `./conferences/<year>-<event>/`).
+2. Copy everything under `themes/conference/template/` into the target folder verbatim. No `npm install`, no dependencies.
+3. Tell the user:
+   - `make dev` serves `presentation.html` on `http://localhost:2663`.
+   - `make notes` serves `notes.html` (open on a phone for a teleprompter).
+   - Edit `presentation.html` to change slide content.
+   - Edit `presentation.md` to change speaker notes, then regenerate `notes.html` from it.
+4. If the user wants `make deploy` to work, ask for their site repo path and the public URL pattern, then update `SITE_REPO`, `PUBLIC_NOTES_URL`, and `PUBLIC_PRESENTATION_URL` at the top of the `Makefile`.
+
+### File layout
+
+```
+<deck-dir>/
+├── presentation.html   # The deck (single hand-edited HTML file)
+├── presentation.md     # Single source of truth for speaker notes
+├── notes.html          # Baked teleprompter sheet (regenerated from md)
+├── Makefile            # dev / notes / deploy / deploy-presentation / deploy-notes / lab / help
+├── images/             # QR codes, photos, diagrams
+└── README.md           # Quick start, conventions
+```
+
+### Slide markup conventions
+
+- Each slide is a `<section class="slide <type>" data-name="<unique-id>">` block.
+- Each slide uses an **eyebrow + heading** pattern: `<div class="label-in">Section name</div>` then `<h3>One central idea</h3>` (or `<h1>` for title slides, `<h2>` for disclaimer / punch).
+- Slides that should reveal items one-at-a-time on Right have `data-reveal="true"` and mark each fragment with `class="revealable"`.
+- The provided slide types: `title`, `disclaimer`, `content`, `chartslide`, `punch` (section divider), `regtable` (two-column bad-vs-good table, optionally `recap-hero`), `jokes` (progressive reveal list with punchline), `title split` (title + image / QR on the right).
+
+### Copy conventions
+
+- **No em-dashes.** Use a regular hyphen. Do not "tidy up" hyphens into em-dashes anywhere.
+- **No full stops at the end of slide leads or headings.** Body text and notes are normal prose.
+- One central idea per slide. Whitespace-led. The slide is not the script.
+
+### Colour convention
+
+Apply consistently when colouring words, lines, table rows, and markers.
+
+| Token | Hex | Meaning |
+|-------|-----|---------|
+| Red    | `#e8503a` | Bad / dysregulating / warning |
+| Green  | `#6bbf73` | Good / regulating / managing |
+| Blue   | `#4c8dd6` | Accent / anchored to baseline |
+| Yellow | `#f2c94c` | Support / highlight |
+
+The slate accent (`#5e8a9c`) and warm rust (`#d99161`) are the deck's neutral accents - eyebrows, section punches, decorative rules.
+
+### Speaker notes flow
+
+- `presentation.md` is the **single source of truth** for speaker notes. The deck (`presentation.html`) is the public artefact and should not carry full notes inline.
+- Each slide in `presentation.md` is a `##` or `###` heading. On-slide content sits above `---`; speaker notes sit below `---`. End each notes block with `*Clock: X:XX*` for pacing.
+- Top-level `#` headings in the md are the author's organising structure (parts / acts) - they are scaffolding, not slides. Skip them when regenerating.
+- When notes change, regenerate `notes.html` by rewriting the entries inside its `<div id="list">` block from the parsed md, pairing each md slide by index with the deck's `data-name` order. Keep the `notes.html` shell (CSS, controls bar, fonts / theme JS) untouched.
+
+### Deploy pattern
+
+`make deploy-presentation` and `make deploy-notes` publish straight to the `gh-pages` branch of `SITE_REPO` via a throwaway `git worktree`. Each pushes a single commit. The deck lives at `<site>/presentation/presentation.html`; the notes sheet lives at `<site>/presentation/notes.html`. The phone-readable notes URL is meant to be opened on a second screen during the talk.
+
 ## Example Interactions
 
 **User**: "Add slides to this project"
-1. Ask where to keep them (suggest `./slides`)
-2. Scaffold folder with `theme: default`
-3. Run `npm install`
-4. Tell user: `cd slides && make slides` to open in browser
+1. Ask: "Slidev (default) or conference (hand-built HTML)?"
+2. If Slidev: ask where to keep them (suggest `./slides`), scaffold folder with `theme: default`, run `npm install`, tell user `cd slides && make slides` to open.
+3. If conference: ask where to keep the deck (suggest `./presentation` or `./conferences/<year>-<event>/`), copy `themes/conference/template/*` into it, tell user `make dev` to open.
+
+**User**: "Create a conference talk deck" or "Set up a hand-built HTML deck"
+1. Skip the Slidev question - go straight to conference mode.
+2. Ask where to keep the deck.
+3. Copy `themes/conference/template/*` into the target folder.
+4. Tell user: `make dev` to preview, edit `presentation.html` for content and `presentation.md` for notes, regenerate `notes.html` from md when notes change.
 
 **User**: "Create slides from the README"
 1. If slides folder exists, read `slides.md` to understand current state

--- a/plugins/dwmkerr/skills/slides/themes/conference/template/Makefile
+++ b/plugins/dwmkerr/skills/slides/themes/conference/template/Makefile
@@ -1,0 +1,75 @@
+default: help
+
+PORT ?= 2663
+
+# Local clone of the GitHub Pages site that hosts the public deck. We publish
+# by pushing directly to the `gh-pages` branch via a throwaway worktree, so
+# changes go live immediately. Customise SITE_REPO and the *_URL vars for your
+# own site, or comment out the deploy targets if you do not publish.
+SITE_REPO ?= $(HOME)/path/to/your-site-repo
+GH_PAGES_WORKTREE := /tmp/conference-deck-gh-pages
+PUBLIC_NOTES_URL := https://example.com/presentation/notes.html
+PUBLIC_PRESENTATION_URL := https://example.com/presentation/presentation.html
+
+.PHONY: help
+help: # Show help for each of the Makefile recipes.
+	@grep -E '^[a-zA-Z0-9 -]+:.*#'  Makefile | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
+
+.PHONY: dev
+dev: # Serve the deck locally and open it in the browser.
+	@echo "Serving on http://localhost:$(PORT)/presentation.html (Ctrl-C to stop)"
+	@open "http://localhost:$(PORT)/presentation.html" || true
+	@python3 -m http.server $(PORT)
+
+.PHONY: notes
+notes: # Serve and open the speaker-notes sheet.
+	@echo "Serving on http://localhost:$(PORT)/notes.html (Ctrl-C to stop)"
+	@open "http://localhost:$(PORT)/notes.html" || true
+	@python3 -m http.server $(PORT)
+
+.PHONY: lab
+lab: # Serve and open any local labs (drafts/*.html). Edit the open list to taste.
+	@open "http://localhost:$(PORT)/drafts/" || true
+	@python3 -m http.server $(PORT)
+
+.PHONY: deploy-presentation
+deploy-presentation: # Publish presentation.html and its assets to gh-pages.
+	@test -d "$(SITE_REPO)" || (echo "SITE_REPO not found: $(SITE_REPO)" && exit 1)
+	cd "$(SITE_REPO)" && git fetch origin gh-pages
+	@if [ -e "$(GH_PAGES_WORKTREE)" ]; then \
+		echo "Removing stale worktree at $(GH_PAGES_WORKTREE)"; \
+		cd "$(SITE_REPO)" && git worktree remove --force "$(GH_PAGES_WORKTREE)" 2>/dev/null || true; \
+		rm -rf "$(GH_PAGES_WORKTREE)"; \
+	fi
+	cd "$(SITE_REPO)" && git worktree add "$(GH_PAGES_WORKTREE)" gh-pages
+	mkdir -p "$(GH_PAGES_WORKTREE)/presentation/images"
+	cp presentation.html "$(GH_PAGES_WORKTREE)/presentation/presentation.html"
+	@if [ -d images ]; then cp -R images/* "$(GH_PAGES_WORKTREE)/presentation/images/" 2>/dev/null || true; fi
+	cd "$(GH_PAGES_WORKTREE)" && git add presentation && \
+		git commit -m "chore: update presentation (gh-pages direct)" && \
+		git push origin gh-pages
+	cd "$(SITE_REPO)" && git worktree remove --force "$(GH_PAGES_WORKTREE)"
+	@echo ""
+	@echo "Published. View: $(PUBLIC_PRESENTATION_URL)"
+
+.PHONY: deploy-notes
+deploy-notes: # Publish notes.html to gh-pages so it can be viewed on a phone.
+	@test -d "$(SITE_REPO)" || (echo "SITE_REPO not found: $(SITE_REPO)" && exit 1)
+	cd "$(SITE_REPO)" && git fetch origin gh-pages
+	@if [ -e "$(GH_PAGES_WORKTREE)" ]; then \
+		echo "Removing stale worktree at $(GH_PAGES_WORKTREE)"; \
+		cd "$(SITE_REPO)" && git worktree remove --force "$(GH_PAGES_WORKTREE)" 2>/dev/null || true; \
+		rm -rf "$(GH_PAGES_WORKTREE)"; \
+	fi
+	cd "$(SITE_REPO)" && git worktree add "$(GH_PAGES_WORKTREE)" gh-pages
+	mkdir -p "$(GH_PAGES_WORKTREE)/presentation"
+	cp notes.html "$(GH_PAGES_WORKTREE)/presentation/notes.html"
+	cd "$(GH_PAGES_WORKTREE)" && git add presentation/notes.html && \
+		git commit -m "chore: update presentation notes (gh-pages direct)" && \
+		git push origin gh-pages
+	cd "$(SITE_REPO)" && git worktree remove --force "$(GH_PAGES_WORKTREE)"
+	@echo ""
+	@echo "Published. View on phone: $(PUBLIC_NOTES_URL)"
+
+.PHONY: deploy
+deploy: deploy-presentation deploy-notes # Publish both presentation and notes to gh-pages.

--- a/plugins/dwmkerr/skills/slides/themes/conference/template/README.md
+++ b/plugins/dwmkerr/skills/slides/themes/conference/template/README.md
@@ -1,0 +1,76 @@
+# Conference Deck
+
+Hand-built HTML conference deck. No framework. No build step. Edit the HTML directly.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `presentation.html` | The deck. One `<section class="slide ...">` per slide. |
+| `presentation.md`   | Single source of truth for speaker notes. |
+| `notes.html`        | Baked teleprompter sheet, regenerated from `presentation.md`. |
+| `Makefile`          | `dev`, `notes`, `deploy`, `deploy-presentation`, `deploy-notes`, `lab`, `help`. |
+| `images/`           | Local assets (QR codes, photos, diagrams). |
+
+## Quick start
+
+```sh
+make dev      # serve presentation.html on http://localhost:2663
+make notes    # serve notes.html (use on a phone as a teleprompter)
+make help     # list all targets
+```
+
+To publish to GitHub Pages, set `SITE_REPO` (and `PUBLIC_*_URL`) at the top of the `Makefile` to point at your `dwmkerr.com`-style site repo, then `make deploy`.
+
+## Editing
+
+Edit `presentation.html` to change a slide's structure or on-slide text. Each slide is a `<section class="slide ...">` with a `data-name` attribute used as its label.
+
+Edit `presentation.md` to change speaker notes. Headings (`##` / `###`) map by index to slides in document order. The block above `---` is on-slide content for your reference; the block below is what you say. End each notes block with `*Clock: X:XX*`.
+
+After editing notes in the md, regenerate `notes.html` by rewriting the entries inside `<div id="list">` from the parsed md. Keep the `notes.html` shell (CSS, controls bar, scripts) unchanged.
+
+## Keyboard
+
+| Key | Action |
+|-----|--------|
+| Right / Space / PageDown | Next slide (reveals fragments first on reveal slides) |
+| Left  / PageUp           | Previous slide (un-reveals fragments first) |
+| Up                       | Show in-deck speaker-notes overlay |
+| Down                     | Hide overlay |
+| F                        | Toggle fullscreen |
+| Home / End               | First / last slide |
+
+Slides with `data-reveal="true"` reveal `.revealable` items one at a time on Right.
+
+## Colour convention
+
+Apply consistently when colouring words, lines, table rows, and markers.
+
+| Token | Hex | Meaning |
+|-------|-----|---------|
+| Red    | `#e8503a` | Bad / dysregulating / warning |
+| Green  | `#6bbf73` | Good / regulating / managing |
+| Blue   | `#4c8dd6` | Accent / anchored to baseline |
+| Yellow | `#f2c94c` | Support / highlight |
+
+The slate accent `#5e8a9c` and warm rust `#d99161` are the deck's neutral accents (eyebrows, section punches, decorative rules).
+
+## Copy conventions
+
+- **No em-dashes**. Use a regular hyphen. Do not let an editor or model "tidy up" hyphens into em-dashes.
+- **No full stops at the end of slide leads or headings**. Body text and notes are normal prose.
+- One central idea per slide. Whitespace-led. The slide is not the script.
+
+## Slide types provided
+
+- `title`       Title slide (talk title + author line).
+- `disclaimer`  Warm-rust eyebrow above a big heading, plus a short paragraph.
+- `content`     Standard eyebrow + heading + body / list slide.
+- `chartslide`  Eyebrow + heading + a chart canvas (`.chart-wrap`).
+- `punch`       Full-wash slate section divider.
+- `regtable`    Two-column comparison table (bad vs good). `.recap-hero` upgrades the heading to title-page size.
+- `jokes`       Progressive-reveal list with a punchline blockquote.
+- `title split` Title-page style with an image (QR or photo) on the right.
+
+Mix and match. Add your own slide types by adding a new class and a CSS block.

--- a/plugins/dwmkerr/skills/slides/themes/conference/template/notes.html
+++ b/plugins/dwmkerr/skills/slides/themes/conference/template/notes.html
@@ -1,0 +1,200 @@
+<!doctype html>
+<!--
+  notes.html - BAKED TELEPROMPTER SHEET.
+
+  This is the standalone speaker-notes view. Big readable text, dark or light
+  theme, font-size buttons, works offline via file:// on a phone or second
+  screen.
+
+  The shell (CSS, controls bar, theme/font-scale JS) does not change. Only the
+  `<div id="list">` block of entries is regenerated.
+
+  Regeneration source: presentation.md.
+
+  Process to regenerate:
+    1. Parse `##` and `###` headings from presentation.md in document order
+       (skip top-level `#` headings; those are scaffolding, not slides).
+    2. Pair each slide by index with a slide in presentation.html using its
+       `data-name` attribute. The label shown next to the entry is the
+       data-name.
+    3. Extract speaker notes for each slide: everything between the `---`
+       separator and the next `##`/`###` heading, including the trailing
+       `*Clock: X:XX*` line.
+    4. Rewrite the entries inside `<div id="list">` below. Each entry is:
+         <div class="entry">
+           <div class="label"><span class="num">N</span><span>data-name</span></div>
+           <div class="notes">notes prose</div>
+         </div>
+       (Add `class="entry empty"` if a slide has no notes.)
+    5. Update the status line: "X slides &middot; Y with notes". A slide counts
+       as "with notes" if its prose has at least 10 words and is not a
+       placeholder.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Speaker Notes</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #0c0e12;
+    --card: #16191f;
+    --ink: #fbfaf6;
+    --ink-soft: #c8c5ba;
+    --muted: #8a8578;
+    --rule: #2c313a;
+    --accent: #5e8a9c;
+    --notes-scale: 1;
+  }
+  /* Light-theme overrides */
+  body.light {
+    --bg: #fbfaf6;
+    --card: #ffffff;
+    --ink: #16191f;
+    --ink-soft: #3a3f48;
+    --muted: #6b6a62;
+    --rule: #e2ded2;
+    --accent: #3f6b7d;
+  }
+
+  * { box-sizing: border-box; }
+  html, body {
+    margin: 0; padding: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    font-feature-settings: "ss01","cv11";
+    -webkit-text-size-adjust: 100%;
+  }
+
+  /* Sticky controls bar */
+  .bar {
+    position: sticky; top: 0; z-index: 10;
+    display: flex; align-items: center; gap: .75rem;
+    padding: .6rem .9rem;
+    background: color-mix(in srgb, var(--bg) 92%, transparent);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--rule);
+  }
+  .bar .title {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: .72rem; letter-spacing: .12em; text-transform: uppercase;
+    color: var(--muted); margin-right: auto;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .btn {
+    appearance: none; border: 1px solid var(--rule);
+    background: var(--card); color: var(--ink);
+    font-family: 'JetBrains Mono', monospace; font-weight: 700;
+    font-size: 1rem;
+    min-width: 3rem; min-height: 3rem;
+    border-radius: .6rem; cursor: pointer;
+    display: inline-flex; align-items: center; justify-content: center;
+    line-height: 1; padding: 0 .6rem;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .btn:active { transform: scale(.96); }
+  .btn.small { font-size: .8rem; }
+
+  main {
+    max-width: 44rem;
+    margin: 0 auto;
+    padding: 1.25rem 1.1rem 6rem;
+  }
+
+  .status {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: .8rem; color: var(--muted);
+    padding: 2rem .2rem;
+  }
+
+  .entry {
+    padding: 1.6rem 0 1.8rem;
+    border-bottom: 1px solid var(--rule);
+  }
+  .entry:last-child { border-bottom: none; }
+
+  .label {
+    font-family: 'JetBrains Mono', monospace;
+    font-size: .8rem; font-weight: 500;
+    letter-spacing: .1em; text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: .7rem;
+    display: flex; align-items: baseline; gap: .6rem;
+  }
+  .label .num {
+    color: var(--muted);
+    font-weight: 700;
+  }
+
+  .notes {
+    font-size: calc(1.65rem * var(--notes-scale));
+    line-height: 1.5;
+    color: var(--ink);
+    font-weight: 400;
+    white-space: pre-wrap;
+  }
+
+  .entry.empty .notes {
+    color: var(--muted);
+    font-style: italic;
+    opacity: .55;
+    font-size: calc(1.15rem * var(--notes-scale));
+  }
+  .entry.empty .label { color: var(--muted); }
+
+  /* Wider screens: slightly smaller base, comfortable column width */
+  @media (min-width: 700px) {
+    .notes { font-size: calc(1.5rem * var(--notes-scale)); }
+  }
+</style>
+</head>
+<body>
+  <div class="bar">
+    <span class="title">Speaker Notes</span>
+    <button class="btn small" id="theme" title="Toggle light / dark">&#9788;</button>
+    <button class="btn" id="dec" title="Smaller text">A&#8722;</button>
+    <button class="btn" id="inc" title="Larger text">A&#43;</button>
+  </div>
+
+  <main>
+    <div class="status" id="status">0 slides &middot; 0 with notes</div>
+    <div id="list">
+    <!-- TEMPLATE NOTE: Regenerate entries below from presentation.md.
+         One <div class="entry"> per slide. See instructions at the top. -->
+    <div class="entry empty">
+      <div class="label"><span class="num">1</span><span>title</span></div>
+      <div class="notes">(notes will be generated from presentation.md)</div>
+    </div>
+    </div>
+  </main>
+
+  <script>
+    // Font scale (persisted across sessions on the same device).
+    const SCALE_KEY = 'notes.scale';
+    let scale = parseFloat(localStorage.getItem(SCALE_KEY) || '1') || 1;
+    function applyScale() {
+      scale = Math.min(2.5, Math.max(0.6, scale));
+      document.documentElement.style.setProperty('--notes-scale', scale.toFixed(2));
+      localStorage.setItem(SCALE_KEY, scale.toFixed(2));
+    }
+    applyScale();
+    document.getElementById('inc').addEventListener('click', () => { scale += 0.12; applyScale(); });
+    document.getElementById('dec').addEventListener('click', () => { scale -= 0.12; applyScale(); });
+
+    // Theme (persisted).
+    const THEME_KEY = 'notes.theme';
+    function applyTheme(t) {
+      document.body.classList.toggle('light', t === 'light');
+      localStorage.setItem(THEME_KEY, t);
+    }
+    applyTheme(localStorage.getItem(THEME_KEY) || 'dark');
+    document.getElementById('theme').addEventListener('click', () => {
+      applyTheme(document.body.classList.contains('light') ? 'dark' : 'light');
+    });
+  </script>
+</body>
+</html>

--- a/plugins/dwmkerr/skills/slides/themes/conference/template/presentation.html
+++ b/plugins/dwmkerr/skills/slides/themes/conference/template/presentation.html
@@ -1,0 +1,518 @@
+<!doctype html>
+<!--
+  CONFERENCE DECK TEMPLATE
+  ------------------------
+  Hand-built HTML conference deck. No framework, no build step.
+
+  Editing model:
+    - This file is the deck. Edit `<section class="slide ...">` blocks directly.
+    - `presentation.md` is the single source of truth for SPEAKER NOTES.
+    - `notes.html` is the baked teleprompter sheet, regenerated FROM presentation.md.
+
+  Navigation (keyboard):
+    Right / Space / PageDown   Next slide (reveals fragments first on reveal slides)
+    Left  / PageUp              Previous slide (un-reveals fragments first)
+    Up                          Show speaker-notes overlay
+    Down                        Hide speaker-notes overlay
+    F                           Toggle fullscreen
+    Home / End                  First / last slide
+
+  Colour convention (apply consistently):
+    Red    #e8503a   bad / dysregulating / warning
+    Green  #6bbf73   good / regulating / managing
+    Blue   #4c8dd6   accent / anchored
+    Yellow #f2c94c   support / highlight
+
+  Copy conventions:
+    - No em-dashes. Use a regular hyphen.
+    - No full stops at the end of slide leads / headings.
+    - One central heading + subtext + optional image per slide. Whitespace-led.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Conference Deck</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --bg: #16191f;          /* near-black slide */
+    --ink: #fbfaf6;         /* ivory text */
+    --ink-soft: #c8c5ba;    /* softer ivory */
+    --rule: #2c313a;
+    --accent: #5e8a9c;      /* slate */
+    --warm: #d99161;        /* warm rust */
+    --muted: #8a8578;
+    /* Convention palette - reference in slides via inline color or utility classes */
+    --bad: #e8503a;
+    --good: #6bbf73;
+    --info: #4c8dd6;
+    --highlight: #f2c94c;
+  }
+
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; height: 100%; background: #0c0e12; overflow: hidden;
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    font-feature-settings: "ss01","cv11";
+  }
+
+  .stage { position: relative; width: 100vw; height: 100vh; display: flex; align-items: center; justify-content: center; }
+
+  /* 16:9 slide locked to viewport */
+  .slide {
+    position: absolute;
+    aspect-ratio: 16 / 9;
+    width: min(96vw, 170vh);
+    background: var(--bg);
+    color: var(--ink);
+    box-shadow: 0 30px 80px rgba(0,0,0,.5);
+    display: none;
+    overflow: hidden;
+  }
+  .slide.active { display: flex; }
+
+  .pad {
+    width: 100%; height: 100%;
+    padding: 6% 7%;
+    display: flex; flex-direction: column; justify-content: center;
+    position: relative;
+  }
+
+  /* Chrome: page number, eyebrow label, footer */
+  .pageno {
+    position: fixed; right: 24px; bottom: 18px;
+    font: 500 13px 'JetBrains Mono', monospace;
+    color: #6f6b5f; letter-spacing: .05em; z-index: 50;
+  }
+  .label-in {
+    font: 500 11px 'JetBrains Mono', monospace;
+    color: var(--muted); letter-spacing: .18em; text-transform: uppercase;
+    margin-bottom: 26px;
+  }
+
+  /* === TITLE === */
+  .title .pad { justify-content: center; align-items: flex-start; }
+  .title h1 {
+    font: 800 clamp(40px, 6.2vw, 84px)/1.02 'Inter', sans-serif;
+    letter-spacing: -.035em;
+    margin: 0 0 30px;
+    max-width: 16ch;
+  }
+  .title .meta {
+    position: absolute; bottom: 7%; left: 7%;
+    font: 500 13px 'JetBrains Mono', monospace;
+    color: var(--muted); letter-spacing: .08em;
+  }
+  .title .meta a { color: var(--muted); text-decoration: none; }
+  .title .meta a:hover { color: var(--ink-soft); }
+
+  /* Title-with-artwork split: title left, image right */
+  .title.split .pad { flex-direction: row; align-items: center; gap: 6%; }
+  .title.split .lead { flex: 0 0 34%; }
+  .title.split .art { flex: 1; display: flex; flex-direction: column; align-items: flex-end; gap: 12px; }
+  .title.split .frame {
+    position: relative; width: 100%; max-height: 64vh; aspect-ratio: 4 / 3;
+    border: 1px dashed var(--rule);
+    display: flex; align-items: center; justify-content: center;
+  }
+  .title.split .frame .ph-label {
+    font: 500 11px 'JetBrains Mono', monospace;
+    color: var(--muted); letter-spacing: .14em; text-transform: uppercase;
+    text-align: center; padding: 0 12%;
+  }
+  .title.split .frame img {
+    position: absolute; inset: 0; width: 100%; height: 100%;
+    object-fit: contain; display: block;
+  }
+  .title.split .caption {
+    font: 400 11px 'JetBrains Mono', monospace;
+    color: var(--muted); letter-spacing: .03em; text-align: right;
+  }
+  /* Thanks slide QR variant - small square sitting on the right. */
+  .title.split[data-name="thanks"] .frame {
+    width: 25%; max-height: 25vh; aspect-ratio: 1 / 1;
+    align-self: flex-end;
+    border: none;
+  }
+
+  /* === DISCLAIMER === */
+  .disclaimer .pad { justify-content: center; }
+  .disclaimer .label-in { color: var(--warm); margin-bottom: 26px; }
+  .disclaimer h2 {
+    font: 800 clamp(40px, 5.4vw, 72px)/1 'Inter', sans-serif;
+    letter-spacing: -.03em; margin: 0 0 30px;
+  }
+  .disclaimer p {
+    font: 400 clamp(18px, 1.9vw, 26px)/1.5 'Inter', sans-serif;
+    color: var(--ink-soft); max-width: 40ch; margin: 0 0 14px;
+  }
+
+  /* === SECTION PUNCH (slate wash divider) === */
+  .punch { background: linear-gradient(135deg, #2f4b57 0%, #243b45 100%); color: var(--ink); }
+  .punch .pad { justify-content: center; }
+  .punch .chapter {
+    font: 500 12px 'JetBrains Mono', monospace;
+    color: rgba(251,250,246,.5);
+    letter-spacing: .3em; margin-bottom: 28px; text-transform: uppercase;
+  }
+  .punch h2 {
+    font: 900 clamp(56px, 9vw, 130px)/.95 'Inter', sans-serif;
+    letter-spacing: -.045em; margin: 0; color: var(--ink);
+  }
+  .punch .tag {
+    margin-top: 28px;
+    font: 400 clamp(16px, 1.5vw, 22px)/1.5 'Inter', sans-serif;
+    color: rgba(251,250,246,.7); max-width: 38ch;
+  }
+
+  /* === CONTENT (eyebrow + heading + body) === */
+  .content .pad { justify-content: flex-start; padding-top: 9%; }
+  .content h3 {
+    font: 800 clamp(28px, 3.4vw, 44px)/1.1 'Inter', sans-serif;
+    letter-spacing: -.02em; margin: 0 0 22px;
+  }
+  .content p {
+    font: 400 clamp(16px, 1.7vw, 22px)/1.5 'Inter', sans-serif;
+    color: var(--ink-soft); max-width: 64ch; margin: 0 0 14px;
+  }
+  .content ul { list-style: none; margin: 0; padding: 0;
+    font: 400 clamp(16px, 1.7vw, 22px)/1.7 'Inter', sans-serif; color: var(--ink-soft); max-width: 64ch; }
+  .content ul li { padding-left: 1.2em; position: relative; }
+  .content ul li::before { content: "—"; position: absolute; left: 0; color: var(--accent); }
+
+  /* === CHART (eyebrow + heading + inline svg/iframe canvas) === */
+  .chartslide .pad { justify-content: flex-start; padding-top: 9%; }
+  .chartslide h3 {
+    font: 800 clamp(28px, 3.4vw, 44px)/1.1 'Inter', sans-serif;
+    letter-spacing: -.02em; margin: 0 0 22px;
+  }
+  .chartslide .chart-wrap { width: 100%; }
+  .chartslide .chart-wrap.placeholder {
+    aspect-ratio: 16 / 5;
+    border: 1px dashed var(--rule);
+    display: flex; align-items: center; justify-content: center;
+    color: var(--muted);
+    font: 500 11px 'JetBrains Mono', monospace;
+    letter-spacing: .18em; text-transform: uppercase;
+  }
+  .chartslide svg { width: 100%; height: auto; display: block; }
+  .chartslide .note {
+    margin-top: 22px;
+    font: 400 clamp(15px, 1.5vw, 20px)/1.5 'Inter', sans-serif;
+    color: var(--ink-soft); max-width: 64ch;
+  }
+
+  /* === RECAP TABLE (two-column comparison: bad vs good) === */
+  .regtable .pad { justify-content: center; padding: 4.5% 6%; }
+  .regtable h3 {
+    font: 800 clamp(24px, 3vw, 38px)/1.1 'Inter', sans-serif;
+    letter-spacing: -.02em; margin: 0 0 20px;
+  }
+  .regtable table { width: 100%; border-collapse: collapse; }
+  .regtable thead th {
+    text-align: left; padding: 0 0 12px;
+    font: 500 11px 'JetBrains Mono', monospace;
+    letter-spacing: .14em; text-transform: uppercase;
+  }
+  .regtable thead .bad { color: var(--bad); }
+  .regtable thead .good { color: var(--good); }
+  .regtable tbody td {
+    padding: 11px 14px 11px 0; vertical-align: top;
+    border-top: 1px solid var(--rule);
+    font: 400 clamp(13px, 1.4vw, 17px)/1.4 'Inter', sans-serif;
+    width: 50%;
+  }
+  .regtable td.bad { color: #f0a594; }
+  .regtable td.good { color: #a9d9ad; }
+  /* Recap bookend: heading rendered as a title-page hero */
+  .regtable.recap-hero .pad { justify-content: flex-start; padding-top: 6%; }
+  .regtable.recap-hero h3 {
+    font: 800 clamp(36px, 5.4vw, 76px)/1.02 'Inter', sans-serif;
+    letter-spacing: -.035em; margin: 0 0 32px; max-width: 16ch;
+  }
+
+  /* === JOKES / REVEAL LIST (right-arrow progressive reveal) === */
+  .jokes .pad { justify-content: center; padding: 5% 7%; }
+  .jokes .label-in { margin-bottom: 14px; }
+  .jokes h3 {
+    font: 800 clamp(26px, 3vw, 40px)/1.1 'Inter', sans-serif;
+    letter-spacing: -.02em; margin: 0 0 8px;
+  }
+  .jokes .sub {
+    font: 400 clamp(15px, 1.5vw, 20px)/1.5 'Inter', sans-serif;
+    color: var(--ink-soft); margin: 0 0 24px;
+  }
+  .jokes ul { columns: 2; column-gap: 56px; list-style: none; margin: 0; padding: 0;
+    font: 400 clamp(14px, 1.45vw, 19px)/1.85 'JetBrains Mono', monospace; color: var(--muted); }
+  .jokes li { break-inside: avoid; }
+  .jokes li::before { content: "\201C"; color: var(--warm); }
+  .jokes li::after  { content: "\201D"; color: var(--warm); }
+  /* Progressive reveal: hidden by default, shown when .revealed is added.
+     visibility:hidden preserves layout so items appearing do not shift the page. */
+  .revealable { visibility: hidden; }
+  .revealable.revealed { visibility: visible; }
+  .jokes blockquote {
+    margin: 28px 0 0; padding: 0 0 0 24px;
+    border-left: 3px solid var(--warm);
+    font: 400 clamp(15px, 1.5vw, 20px)/1.5 'Inter', sans-serif;
+    color: var(--ink); max-width: 70ch; font-style: italic;
+  }
+
+  /* === SPEAKER NOTES OVERLAY (in-deck) ===
+     Slides up from the bottom, overlays the deck without resizing the 16:9 frame.
+     Used only as a quick in-deck reference; the full notes live in notes.html. */
+  .notes {
+    position: fixed; left: 0; right: 0; bottom: 0;
+    height: 30vh;
+    background: #0b0d11;
+    border-top: 1px solid #2c313a;
+    color: var(--ink);
+    box-shadow: 0 -20px 40px rgba(0,0,0,.5);
+    z-index: 60;
+    transform: translateY(100%);
+    transition: transform .28s ease;
+    padding: 26px 40px 40px;
+    overflow-y: auto;
+  }
+  .notes.show { transform: translateY(0); }
+  .notes .notes-label {
+    font: 500 11px 'JetBrains Mono', monospace;
+    color: var(--muted); letter-spacing: .18em; text-transform: uppercase;
+    margin-bottom: 14px;
+  }
+  .notes .notes-body {
+    font: 400 clamp(16px, 1.6vw, 22px)/1.5 'Inter', sans-serif;
+    color: var(--ink-soft); max-width: 80ch;
+    white-space: pre-wrap;
+  }
+</style>
+</head>
+<body>
+
+<div class="stage">
+
+  <!-- TEMPLATE NOTE: Title slide. Drop your talk title in <h1>. Replace the
+       meta line with your name and links. Match the title in <title> above. -->
+  <section class="slide title" data-name="title">
+    <div class="pad">
+      <h1>Your Talk Title Here</h1>
+      <div class="meta">Your Name &middot; <a href="https://github.com/you">github.com/you</a> &middot; <a href="https://linkedin.com/in/you">linkedin.com/in/you</a></div>
+    </div>
+  </section>
+
+  <!-- TEMPLATE NOTE: Disclaimer / framing slide. Optional. Use the .disclaimer
+       class when you want a warm-rust eyebrow above a big heading. -->
+  <section class="slide disclaimer" data-name="disclaimer">
+    <div class="pad">
+      <div class="label-in">A note before we start</div>
+      <h2>Disclaimer</h2>
+      <p>Short framing sentence in body copy. One or two lines is enough.</p>
+    </div>
+  </section>
+
+  <!-- TEMPLATE NOTE: Standard content slide. Eyebrow (.label-in), heading,
+       body / list. Use this for most slides. -->
+  <section class="slide content" data-name="content-example">
+    <div class="pad">
+      <div class="label-in">Section name</div>
+      <h3>One central idea</h3>
+      <ul>
+        <li>Point one</li>
+        <li>Point two</li>
+        <li>Point three</li>
+      </ul>
+    </div>
+  </section>
+
+  <!-- TEMPLATE NOTE: Chart slide. Drop an inline <svg>, an <iframe>, or an
+       <img> into .chart-wrap. The placeholder box below is a hint - replace it. -->
+  <section class="slide chartslide" data-name="chart-example">
+    <div class="pad">
+      <div class="label-in">Section name</div>
+      <h3>Chart slide</h3>
+      <div class="chart-wrap placeholder">Chart goes here</div>
+      <div class="note">One-line caption or takeaway.</div>
+    </div>
+  </section>
+
+  <!-- TEMPLATE NOTE: Section divider. Big full-wash slate punch slide.
+       Use sparingly - one per major section. -->
+  <section class="slide punch" data-name="section-divider">
+    <div class="pad">
+      <div class="chapter">Part Two</div>
+      <h2>Section Title</h2>
+      <div class="tag">Optional subtitle that sets up the next few slides.</div>
+    </div>
+  </section>
+
+  <!-- TEMPLATE NOTE: Recap table. Two-column comparison: bad (red) vs good
+       (green). Use as a bookend at the end of a section or the whole talk. -->
+  <section class="slide regtable recap-hero" data-name="recap">
+    <div class="pad">
+      <h3>Recap</h3>
+      <table>
+        <thead>
+          <tr>
+            <th class="bad">The problem</th>
+            <th class="good">The practice</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="bad">Symptom one</td>
+            <td class="good">Practice one</td>
+          </tr>
+          <tr>
+            <td class="bad">Symptom two</td>
+            <td class="good">Practice two</td>
+          </tr>
+          <tr>
+            <td class="bad">Symptom three</td>
+            <td class="good">Practice three</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- TEMPLATE NOTE: Joke / reveal slide. `data-reveal="true"` enables
+       right-arrow progressive reveal of `.revealable` items in document order.
+       Pressing Left un-reveals in reverse. -->
+  <section class="slide jokes" data-name="ending-jokes" data-reveal="true">
+    <div class="pad">
+      <div class="label-in">ending</div>
+      <h3>Things I almost called this talk</h3>
+      <ul>
+        <li class="revealable">Bad idea one</li>
+        <li class="revealable">Bad idea two</li>
+        <li class="revealable">Bad idea three</li>
+      </ul>
+      <blockquote class="revealable">Punchline or moral once the list has landed.</blockquote>
+    </div>
+  </section>
+
+  <!-- TEMPLATE NOTE: Thanks slide. Title-page style with an image (QR, photo)
+       on the right. Replace `images/qr.svg` or remove the <img> entirely. -->
+  <section class="slide title split" data-name="thanks">
+    <div class="pad">
+      <div class="lead">
+        <h1>Thanks</h1>
+        <div class="meta" style="position:static;left:auto;bottom:auto;margin:24px 0 0">Optional sign-off line</div>
+        <div class="meta" style="position:static;left:auto;bottom:auto;margin:14px 0 0">Your Name &middot; <a href="https://github.com/you">github.com/you</a> &middot; <a href="https://linkedin.com/in/you">linkedin.com/in/you</a></div>
+      </div>
+      <div class="art">
+        <div class="frame">
+          <!-- Replace with your QR or photo. Remove the <img> to show the dashed placeholder. -->
+          <img src="images/qr.svg" alt="QR code" onerror="this.style.display='none'">
+          <div class="ph-label">Image / QR</div>
+        </div>
+        <div class="caption">linkedin.com/in/you</div>
+      </div>
+    </div>
+  </section>
+
+</div>
+
+<!-- Chrome -->
+<div class="pageno" id="pageno">01 / 08</div>
+
+<!-- Speaker notes panel: Up arrow shows, Down arrow hides.
+     Notes are stored per slide in the `data-notes` attribute on each
+     <section class="slide ...">. For full notes on a second screen / phone,
+     use notes.html instead. -->
+<div class="notes" id="notes" aria-hidden="true">
+  <div class="notes-label" id="notes-label">Speaker notes</div>
+  <div class="notes-body" id="notes-body"></div>
+</div>
+
+<script>
+// --- NAV --------------------------------------------------------------------
+const slides = document.querySelectorAll('.slide');
+const total = slides.length;
+let i = 0;
+const pageno = document.getElementById('pageno');
+const stage = document.querySelector('.stage');
+
+const notesPanel = document.getElementById('notes');
+const notesLabel = document.getElementById('notes-label');
+const notesBody = document.getElementById('notes-body');
+
+function updateNotes() {
+  notesLabel.textContent = 'Notes · ' + (slides[i].dataset.name || '');
+  notesBody.textContent = slides[i].dataset.notes || '(no notes)';
+}
+
+function show(idx) {
+  // Reset progressive-reveal state on any reveal slide we are leaving, so it
+  // starts fresh next time it becomes active.
+  if (slides[i] && slides[i].dataset.reveal === 'true') {
+    slides[i].querySelectorAll('.revealable.revealed').forEach((r) => r.classList.remove('revealed'));
+  }
+  i = ((idx % total) + total) % total;
+  slides.forEach((s, k) => s.classList.toggle('active', k === i));
+  pageno.textContent = String(i + 1).padStart(2, '0') + ' / ' + String(total).padStart(2, '0');
+  if (notesPanel.classList.contains('show')) updateNotes();
+}
+
+// Reveal helpers. revealNext returns true if it revealed something (so nav
+// should NOT advance); revealPrev returns true if it un-revealed something
+// (so nav should NOT go back).
+function revealNext() {
+  const cur = slides[i];
+  if (!cur || cur.dataset.reveal !== 'true') return false;
+  const next = cur.querySelector('.revealable:not(.revealed)');
+  if (!next) return false;
+  next.classList.add('revealed');
+  return true;
+}
+function revealPrev() {
+  const cur = slides[i];
+  if (!cur || cur.dataset.reveal !== 'true') return false;
+  const revealed = cur.querySelectorAll('.revealable.revealed');
+  if (!revealed.length) return false;
+  revealed[revealed.length - 1].classList.remove('revealed');
+  return true;
+}
+
+function showNotes() {
+  updateNotes();
+  notesPanel.classList.add('show');
+  notesPanel.setAttribute('aria-hidden', 'false');
+}
+function hideNotes() {
+  notesPanel.classList.remove('show');
+  notesPanel.setAttribute('aria-hidden', 'true');
+}
+
+function toggleFullscreen() {
+  if (!document.fullscreenElement) {
+    (stage.requestFullscreen || stage.webkitRequestFullscreen).call(stage);
+  } else {
+    (document.exitFullscreen || document.webkitExitFullscreen).call(document);
+  }
+}
+
+document.addEventListener('keydown', e => {
+  // Right / Space / PageDown: on a reveal slide, advance the fragment first;
+  // only advance to the next slide once no more fragments remain.
+  if (e.key === 'ArrowRight' || e.key === 'PageDown' || e.key === ' ') {
+    e.preventDefault();
+    if (!revealNext()) show(i + 1);
+  }
+  // Left / PageUp: on a reveal slide, un-reveal the most recent fragment first.
+  else if (e.key === 'ArrowLeft' || e.key === 'PageUp') {
+    e.preventDefault();
+    if (!revealPrev()) show(i - 1);
+  }
+  else if (e.key === 'ArrowUp') { e.preventDefault(); showNotes(); }
+  else if (e.key === 'ArrowDown') { e.preventDefault(); hideNotes(); }
+  else if (e.key === 'f' || e.key === 'F') { e.preventDefault(); toggleFullscreen(); }
+  else if (e.key === 'Home') show(0);
+  else if (e.key === 'End') show(total - 1);
+});
+show(0);
+</script>
+</body>
+</html>

--- a/plugins/dwmkerr/skills/slides/themes/conference/template/presentation.md
+++ b/plugins/dwmkerr/skills/slides/themes/conference/template/presentation.md
@@ -1,0 +1,105 @@
+<!--
+  presentation.md - SINGLE SOURCE OF TRUTH FOR SPEAKER NOTES.
+
+  Structure:
+    # Top-level headings are the author's own organising structure (parts /
+      acts). They are NOT rendered as slides - they are scaffolding for you.
+    ## (or ###) headings are slides, in document order.
+    Each slide block has:
+      - On-slide content (what is written on the deck) above the `---`.
+      - Speaker notes (what you say) below the `---`.
+      - A trailing `*Clock: X:XX*` time target on the last line of the notes.
+
+  Pair these slides by index with the `data-name` attributes in
+  presentation.html when regenerating notes.html.
+
+  Conventions:
+    - No em-dashes. Use a regular hyphen.
+    - No full stops on slide leads / headings.
+-->
+
+# Part One
+
+## Your Talk Title Here
+
+---
+
+Open with a hook. One or two short paragraphs in prose. Speak it the way you would say it on stage. Notes are read out by you, not by the audience.
+
+What is the talk about? Why should the audience care? Why are you the person telling this story?
+
+*Clock: 1:00*
+
+## Disclaimer
+
+A note before we start.
+
+---
+
+Optional framing. If your topic touches mental health, safety, regulated industries, or anything personal, set the tone here. Keep it short. One paragraph.
+
+*Clock: 1:30*
+
+## One central idea
+
+- Point one
+- Point two
+- Point three
+
+---
+
+Most slides look like this. A short eyebrow, a heading, and a few bullets or a short paragraph. Speak around the slide. The slide is not the script.
+
+*Clock: 3:00*
+
+## Chart slide
+
+Image: short description of the chart so you remember what it shows.
+
+---
+
+A chart, diagram, or screenshot. Drop an SVG, an iframe, or an image into the .chart-wrap div in the html. Use the colour convention (red bad, green good, blue anchored, yellow support).
+
+*Clock: 4:30*
+
+# Part Two
+
+## Section Title
+
+Optional subtitle that sets up the next few slides.
+
+---
+
+Section dividers are full-wash slate slides. Use sparingly. One per major section. The chapter label, the big heading, and a one-line tag.
+
+*Clock: 6:00*
+
+## Recap
+
+Two-column comparison of the bad pattern and the good practice.
+
+---
+
+A recap or bookend table. Left column red (the problem). Right column green (the practice). Read across each row.
+
+*Clock: 25:00*
+
+## Things I almost called this talk
+
+- Bad idea one
+- Bad idea two
+- Bad idea three
+
+---
+
+The reveal slide. Right-arrow brings each item in one at a time. Useful for jokes, for leading the audience, for revealing a punchline last. The blockquote at the end is the moral.
+
+*Clock: 28:00*
+
+## Thanks
+
+---
+
+Sign-off slide. QR or photo on the right, your name and links on the left.
+
+*Clock: 30:00*


### PR DESCRIPTION
## Summary
- Add a 'conference' build mode to the slides skill: a single self-contained `presentation.html` deck with a `presentation.md` notes source and baked `notes.html` teleprompter
- Add a reusable template under `themes/conference/template/` (presentation.html, notes.html, presentation.md, Makefile, README)
- Add a 'choose a build approach' chooser (Slidev vs conference); Slidev mode and themes left intact