### PR TITLE
feat(toolkit): add solve-problem skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ If commands don't appear, enable and restart:
         - [`claude-code-plugin-development`](#claude-code-plugin-development)
         - [`learn-and-improve`](#learn-and-improve)
         - [`claude-code-agent-teams`](#claude-code-agent-teams)
+        - [`solve-problem`](#solve-problem)
     - [Agents](#agents)
         - [`researcher`](#researcher)
 - [The `dwmkerr` Plugin](#the-dwmkerr-plugin)
@@ -237,6 +238,16 @@ After running this example, you'll have a statusline similar to the below:
 - Covers team creation, display modes (in-process vs split panes), task assignment, and cleanup
 - Includes decision guide for agent teams vs subagents
 - Best practices for team sizing, task sizing, and avoiding file conflicts
+
+#### `solve-problem`
+
+> solve problem: the burnup chart doesn't render
+
+- Methodical, evidence-first problem solving — resists jumping to the first plausible fix
+- Six moves: understand intent, observe the problem first-hand, form multiple hypotheses, gather discriminating evidence, propose, verify the resolution
+- Domain-neutral — works for code bugs, broken appliances, dropped sales, failing processes
+- Shows its full working (problem, evidence, hypotheses, root cause, confidence) so you can debug the reasoning
+- Invoke explicitly with "solve problem" or `/solve-problem`
 
 ### Agents
 

--- a/plugins/toolkit/skills/solve-problem/SKILL.md
+++ b/plugins/toolkit/skills/solve-problem/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: solve-problem
+description: This skill should be used when the user says "solve problem", "solve this problem", or invokes /solve-problem. Applies a methodical, evidence-first approach to diagnosing a problem - understand intent, observe the problem first-hand, form multiple hypotheses, gather discriminating evidence to eliminate them, propose an evidenced solution, and verify the fix actually resolves the original symptom. Do NOT use for general how-to questions, explanations, or building new features.
+allowed-tools: Read, Grep, Bash
+---
+
+# Solve Problem
+
+A methodical approach to solving a problem. The goal is to resist the instinct to
+jump at the first plausible-sounding fix. That instinct feels fast but causes
+wrong fixes and wasted iteration. Slow down, gather evidence, then propose.
+
+Work through the moves in order. Do not skip ahead. The moves are
+domain-neutral — they apply to a code bug, a broken appliance, a drop in sales,
+or a failing process. Examples below span more than code on purpose.
+
+## 1. Understand intent
+
+Restate the problem in your own words so the user can correct you. Establish what
+they expect, what is actually happening, and what "solved" looks like.
+
+Clarify with the user **only if the problem is genuinely ambiguous**. Do not
+interrogate a clear problem — echo your understanding and move on.
+
+## 2. See the problem — first-hand, repeatably
+
+Confirm the problem is real before hunting for causes. **Observe it directly,
+under conditions you can return to** — don't diagnose from a second-hand report,
+ticket, summary, or a single stale log line. You want a way to make the problem
+happen (or to check whether it's happening) **again on demand**, because the same
+handle confirms the cause now and verifies the fix later (move 6).
+
+Prefer first-hand evidence over artifacts: reproduce the bug by running it; watch
+the real checkout instead of reading the sales dashboard; measure the actual part
+instead of trusting the spec.
+
+If you cannot see it, or it turns out not to be a real problem (wrong expectation,
+already fixed, environment issue), **say so and stop**. Do not invent a fix for a
+problem you have not observed.
+
+## 3. Hypothesize
+
+Once the problem is confirmed, investigate how the thing is *supposed* to work and
+where reality diverges. From that investigation, list **at least two** candidate
+causes.
+
+A single hypothesis is banned — it leads to tunnel vision. Force yourself to name
+alternatives, even ones you think are unlikely.
+
+## 4. Gather evidence
+
+For each hypothesis, run the cheapest check that *discriminates* between causes —
+ideally one that could prove the hypothesis **wrong**, not merely one consistent
+with it. Evidence that merely *fits* a hypothesis (correlation) is weak: it often
+fits competing hypotheses too. ("It works in a clean browser" is consistent with
+*both* "stale state" and "a race" — it rules out neither.) Seek the check that
+*separates* them.
+
+Confirm or eliminate each with first-hand evidence. Assumptions and memory are not
+evidence. If the cheap checks (logs, reports) don't isolate it, **escalate to
+direct observation with more instrumentation** rather than guessing harder. Keep
+eliminating until one cause is supported by evidence that survived an attempt to
+falsify it.
+
+## 5. Propose
+
+Propose a solution grounded in the evidence. State your **confidence level** and
+**what is still uncertain**. If you cannot reach certainty, say so, and say what
+would resolve it.
+
+By default, stop here. Propose — do not implement — unless the user asks you to
+apply the fix.
+
+## 6. Verify the resolution
+
+Once a fix is applied, **re-observe the original symptom under the same conditions
+that showed it** (move 2's handle). The problem is not solved until the thing that
+was wrong is now demonstrably right — observed, not assumed.
+
+This is **not** the same as move 4. Move 4 verifies the *diagnosis* ("is this the
+cause?"); move 6 verifies the *resolution* ("did my action make the symptom
+actually go away?"). They are different questions: a doctor's test can confirm the
+cause, yet the prescribed treatment may still not cure the patient — you check the
+patient got better. You can also mis-apply a *correct* diagnosis (incomplete fix,
+wrong change, a side effect), and only re-observing the symptom catches that.
+
+If the symptom persists, the fix — or the diagnosis behind it — was wrong. Do not
+patch again from the same reasoning; return to move 2 with more instrumentation.
+
+## Anti-rush rules
+
+- No proposal before the problem is **seen first-hand** and a cause is **evidenced**.
+- At least two hypotheses before testing any.
+- Evidence — not memory or assumption — confirms a cause. Prefer a check that could
+  *falsify* the hypothesis over one that merely fits it.
+- **Recurrence means you were wrong.** If the problem comes back after a fix, the
+  cause (or the fix) was wrong — go back to observing it directly with more
+  instrumentation; do **not** propose another fix from the same reasoning.
+- Not solved until **re-observed gone** (move 6), not just "a change was made".
+- State confidence. Flag uncertainty. Never fake certainty.
+
+## Show your working
+
+When presenting the proposal, always show the full trace so the user can debug your
+reasoning. Use this structure:
+
+```
+## Problem
+<the problem, restated>
+
+## How I confirmed it
+<what you reproduced or observed — the evidence it is real>
+
+## Hypotheses considered
+1. <hypothesis> — <eliminated / confirmed>
+2. <hypothesis> — <eliminated / confirmed>
+...
+
+## Evidence
+<per hypothesis: what you checked and what it showed>
+
+## Root cause
+<the cause supported by evidence>
+
+## Proposed solution
+<the fix, grounded in the evidence>
+
+## Confidence
+<high / medium / low> — <what is still uncertain, if anything>
+
+## Verification (after applying)
+<the original symptom re-checked under the same conditions — gone, observed>
+```
+
+## Worked example (non-code)
+
+> **Problem:** "Our checkout conversion dropped last week."
+>
+> 1. **Intent:** conversion fell vs the prior week; "solved" = back to baseline,
+>    cause understood.
+> 2. **See it first-hand:** don't theorise from the dashboard — pull the actual
+>    funnel and *watch session recordings* of failed checkouts (repeatable handle).
+> 3. **Hypotheses:** (a) new shipping-cost step; (b) a payment provider erroring;
+>    (c) a price rise. Two+ before testing.
+> 4. **Discriminating evidence:** segment the drop — if it's *only* one payment
+>    method, that *falsifies* (a) and (c). Find errors isolated to one provider.
+> 5. **Propose:** fix that provider's integration.
+> 6. **Verify:** re-check *that segment's* conversion after the fix — back to
+>    baseline? If not, the cause was wrong; back to step 2.

--- a/plugins/toolkit/skills/solve-problem/SKILL.md
+++ b/plugins/toolkit/skills/solve-problem/SKILL.md
@@ -96,6 +96,14 @@ patch again from the same reasoning; return to move 2 with more instrumentation.
 - **Recurrence means you were wrong.** If the problem comes back after a fix, the
   cause (or the fix) was wrong — go back to observing it directly with more
   instrumentation; do **not** propose another fix from the same reasoning.
+- **The words in the report are hypotheses, not evidence.** "It's a timeout," "it's
+  a race," "it only happens without X" — these are the reporter's model of the bug,
+  often wrong even when plausible. Test them like any other hypothesis; never adopt
+  them as the starting fact.
+- **A constant is a clue.** An exact, repeating number (the same 15s three times)
+  is a deadline or an interval, not how long the work took — work varies, limits
+  don't. When cheap checks can't separate causes, **change the conditions** to make
+  a hidden variable visible rather than staring harder at the same setup.
 - Not solved until **re-observed gone** (move 6), not just "a change was made".
 - State confidence. Flag uncertainty. Never fake certainty.
 
@@ -147,3 +155,15 @@ reasoning. Use this structure:
 > 5. **Propose:** fix that provider's integration.
 > 6. **Verify:** re-check *that segment's* conversion after the fix — back to
 >    baseline? If not, the cause was wrong; back to step 2.
+
+## More worked examples
+
+For full end-to-end traces of the method applied to hard, real problems, see
+[`references/`](references/README.md). Read one when you are stuck and want a model
+to follow. Currently:
+
+- [SSE keepalive misdiagnosed as a timeout](references/example-sse-keepalive-misdiagnosed-as-timeout.md)
+  — a bug *reported* as a "query timeout" that was nothing of the kind. Shows
+  falsifying several plausible causes, escalating instrumentation (throttling a
+  consumer to expose a hidden keepalive), reading dependency source as evidence,
+  and verifying the fix end-to-end.

--- a/plugins/toolkit/skills/solve-problem/references/README.md
+++ b/plugins/toolkit/skills/solve-problem/references/README.md
@@ -1,0 +1,23 @@
+# Worked examples
+
+Real, end-to-end applications of the solve-problem moves. Each is a full trace —
+symptom, hypotheses, discriminating evidence, root cause, fix, verification — kept
+so a future reader can see the method applied to a hard, real problem rather than a
+toy.
+
+When you are working a genuinely confusing problem and want a model to follow, read
+the example whose lesson matches your situation.
+
+| Example | Domain | Core lesson |
+|---------|--------|-------------|
+| [SSE keepalive misdiagnosed as a timeout](example-sse-keepalive-misdiagnosed-as-timeout.md) | Code / distributed systems | The label in the bug report ("timeout") is a hypothesis, not evidence. Exact-constant timing means a deadline/interval, not work. When cheap checks don't isolate it, change the *conditions* to expose the hidden variable. Library source is evidence. |
+
+## What makes a good worked example here
+
+- It shows at least one **wrong-but-plausible** hypothesis being **falsified** by a
+  test, not just the winning one being confirmed.
+- It shows the moment the investigation **escalated instrumentation** because the
+  cheap checks didn't separate the candidates.
+- It states **confidence** and what remained uncertain.
+- It ends with the original symptom **re-observed gone** (move 6), not "a change
+  was made".

--- a/plugins/toolkit/skills/solve-problem/references/example-sse-keepalive-misdiagnosed-as-timeout.md
+++ b/plugins/toolkit/skills/solve-problem/references/example-sse-keepalive-misdiagnosed-as-timeout.md
@@ -1,0 +1,124 @@
+# Worked example: an SSE keepalive bug reported as a "query timeout"
+
+**Repo / proof point:** [dwmkerr/ark-demo](https://github.com/dwmkerr/ark-demo) ·
+**Upstream bug + full trace:** [mckinsey/agents-at-scale-ark#1346](https://github.com/mckinsey/agents-at-scale-ark/issues/1346)
+([root-cause comment](https://github.com/mckinsey/agents-at-scale-ark/issues/1346#issuecomment-4728271299))
+
+A team reported that an AI agent platform (Ark) "fails on queries when streaming is
+off" and called it a **query timeout**. The real cause was nothing to do with a
+timeout. This is the canonical trap the skill exists to prevent: the word in the
+report is a *hypothesis*, and an attractive one, but it is not evidence.
+
+---
+
+## 1. Understand intent
+
+Restated: agents reply fine to short prompts, but a prompt that produces a **long**
+answer fails with `unexpected end of JSON input` and the query ends in `error`.
+Reporter framed it as "works with streaming, not without," and "feels like a
+timeout." "Solved" = long answers complete reliably; cause understood, not guessed.
+
+Note what was *not* accepted at face value: the label "timeout," and the
+"streaming vs non-streaming" framing. Both are the reporter's model of the bug, to
+be tested — not facts.
+
+## 2. See the problem — first-hand, repeatably
+
+Reproduced two independent ways, both giving a handle that fires on demand:
+
+- **CLI:** created a `Query` resource directly against the agent with a
+  long-answer prompt → `phase: error`, message `unexpected end of JSON input`.
+- **UI:** drove the real dashboard chat with the same prompt → identical error.
+  The browser network panel showed the client poll for **~15s**, then the query
+  errored.
+
+Short prompts always succeeded; long prompts always failed; failure always landed
+at **~15 seconds**. That last fact — a *constant* — is the first real clue.
+
+> Lesson: an exact, repeating constant (15s, three times, across two models) is
+> almost never "how long the work took." It is a **deadline or an interval**. Work
+> varies; deadlines don't.
+
+## 3. Hypothesize (≥2, including unlikely ones)
+
+1. The model endpoint truncates long streamed responses.
+2. It's specific to one model/agent (the failing ones used a particular model).
+3. A timeout somewhere in our code/config (the reporter's theory).
+4. The pod's network egress (CNI/NAT) cuts the connection.
+5. The HTTP/SDK client has a default request timeout.
+6. Something in the *content* of the stream — not a timeout at all.
+
+## 4. Gather evidence (cheapest *discriminating* check first; try to falsify)
+
+- **Falsify (2):** ran the same long prompt against a *different* model/agent →
+  also failed. Not model-specific. ✗
+- **Falsify (1) and (4):** reproduced the exact streaming request with `curl`
+  **from the host and from a pod in the cluster** (same egress path the service
+  uses). Both streamed the full long answer in **~24s, HTTP 200, clean
+  termination**. So the endpoint is fine and the network path is fine — and
+  critically, the *full* response needs ~24s, but the service dies at ~15s. ✗✗
+- **Falsify (3):** searched the entire codebase and every dependency in the
+  request path for a 15s timeout. None existed; the only relevant timeout was 5
+  minutes. ✗
+- **Falsify (5):** read the HTTP client / SDK config — default request timeout was
+  zero (disabled). ✗
+- That left (6), but cheap checks hadn't *shown* it. **Escalate instrumentation by
+  changing the conditions:** the service is a *slow* consumer (it forwards each
+  chunk onward between reads), while `curl` drains instantly. So re-ran `curl` with
+  the read **throttled** to mimic a slow consumer.
+
+  The throttled stream revealed what the fast one never did — server keepalive
+  frames, **exactly 15 seconds apart**:
+  ```
+  : ping - 2026-06-17 09:09:52
+  : ping - 2026-06-17 09:10:07
+  : ping - 2026-06-17 09:10:22
+  ```
+  Raw bytes showed each ping is an SSE **comment** line followed by a blank line.
+
+- **Confirm the mechanism in the library source** (dependency code is evidence):
+  the SDK's SSE decoder skips the `: ping` comment but the trailing blank line
+  still *dispatches an event with an empty data buffer*, and the next layer calls
+  `json.Unmarshal([]byte{})` → `unexpected end of JSON input`. Identical in two
+  SDK versions. (This also violates the SSE spec, which says empty-data events must
+  not be dispatched.)
+
+This explains every observation: fast consumers (curl) never trigger a keepalive;
+short answers finish before the first one; the slow service hits one at ~15s on
+long answers. And "works with streaming, fails without" was a red herring — the
+backend always streams; the toggle only changed whether the user saw partial
+tokens before the same error.
+
+## 5. Root cause + propose
+
+The model was configured to use the provider's **OpenAI-compatible** endpoint,
+whose SSE stream the SDK decoder mishandles on **keepalive/comment frames**. The
+upstream provider sends those every 15s; the SDK turns one into a fatal JSON parse
+error. Proposed fixes: (immediate/config) switch the model to the **native
+provider**, which uses a non-SSE request and cannot hit the bug; (upstream/code)
+make the decoder skip comment/empty frames.
+
+Confidence: **high** — every competing hypothesis was falsified with first-hand
+evidence, and the failing mechanism was read directly in the library source.
+
+## 6. Verify the resolution
+
+Re-ran the **same long-answer prompt** (move 2's handle) against an agent using the
+native provider → `phase: done`, full multi-thousand-character essay returned. The
+original symptom, under the original conditions, is gone — observed, not assumed.
+
+---
+
+## Why this is a good teaching case
+
+- **The report's word was wrong.** "Timeout" and "streaming-vs-not" were plausible
+  and both false. Treating them as hypotheses, not facts, is the whole game.
+- **Falsification did the work.** Each cheap test was chosen to *kill* a candidate
+  (different model, host vs pod curl, code search), not to comfort the favourite.
+- **The breakthrough was changing conditions, not looking harder.** Throttling the
+  consumer made an invisible variable (keepalives only sent to slow readers)
+  visible. When cheap checks don't separate causes, change the setup.
+- **Dependency source is evidence.** The decisive confirmation was reading the
+  third-party SDK's decoder, not guessing about it.
+- **It ends verified** — the original symptom re-checked and gone, with the fix
+  confirmed end-to-end before claiming success.

--- a/plugins/toolkit/skills/solve-problem/skill-tests.yaml
+++ b/plugins/toolkit/skills/solve-problem/skill-tests.yaml
@@ -1,0 +1,19 @@
+skill: toolkit:solve-problem
+model: haiku
+
+tests:
+  - id: solve-problem-explicit
+    prompt: "solve problem: the burnup chart doesn't render"
+    should_trigger: true
+
+  - id: solve-this-problem
+    prompt: "solve this problem - users get logged out randomly"
+    should_trigger: true
+
+  - id: how-to-question
+    prompt: "how do I add a burnup chart to my dashboard?"
+    should_trigger: false
+
+  - id: build-feature
+    prompt: "build a new reporting page with export to CSV"
+    should_trigger: false


### PR DESCRIPTION
## Summary
- Add `solve-problem` skill: a methodical, evidence-first approach to diagnosing problems that resists jumping to the first plausible fix.
- Six moves: understand intent, observe the problem first-hand, form multiple hypotheses, gather discriminating evidence, propose, verify the resolution.
- Domain-neutral (code, hardware, process, sales). Shows full working so the reasoning is debuggable.
- Invoked explicitly via "solve problem" or `/solve-problem`.
- Adds `skill-tests.yaml` (positive + negative triggers) and README entries (TOC + Skills section).