### PR TITLE
docs: document installing skills via npx skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ If commands don't appear, enable and restart:
 # rm -rf ~/.claude/plugins/cache
 ```
 
+## Install via `npx skills`
+
+The skills also install without the plugin via [`npx skills`](https://github.com/vercel-labs/skills) (or [`openskills`](https://github.com/numman-ali/openskills)), which copies `SKILL.md` folders into `.claude/skills/` and works with Claude Code, Cursor, Codex, and other agents:
+
+```bash
+npx skills add dwmkerr/claude-toolkit                        # all skills
+npx skills add dwmkerr/claude-toolkit --skill solve-problem  # a single skill
+```
+
+> Note: this installs **all** skills, including the personal `dwmkerr` ones (`my-repos`, `project-setup`, `slides`, `drawio-diagram`). Use `--skill <name>` to pick only what you want.
+
 <!-- vim-markdown-toc GFM -->
 
 - [The `toolkit` Plugin](#the-toolkit-plugin)


### PR DESCRIPTION
## Summary
- Add an "Install via `npx skills`" section: skills install without the plugin via [`npx skills`](https://github.com/vercel-labs/skills) / [`openskills`](https://github.com/numman-ali/openskills), which copy `SKILL.md` folders (references included) into `.claude/skills/`.
- Verified: `npx skills add dwmkerr/claude-toolkit` discovers all 20 skills via the GitHub Trees API; a single-skill install copies the full folder.
- Note that npx installs **all** skills including the personal `dwmkerr` ones; `--skill` selects individual skills.
- skills.sh listing is telemetry-driven — no submission step.