### PR TITLE
docs(toolkit): slides embed cleanup + trailing marketplace & troubleshooting fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,19 +8,19 @@
       "name": "toolkit",
       "source": "./plugins/toolkit",
       "description": "General purpose Claude Code toolkit with research agents, skills, and introspection commands",
-      "version": "0.1.6"
+      "version": "0.1.6-rc4"
     },
     {
       "name": "dwmkerr",
       "source": "./plugins/dwmkerr",
       "description": "Personal Claude Code plugin for dwmkerr with repo management and custom workflows",
-      "version": "0.1.6"
+      "version": "0.1.6-rc4"
     },
     {
       "name": "protocols",
       "source": "./plugins/protocols",
       "description": "Structured protocols for feature exploration and development workflows",
-      "version": "0.1.0-rc2"
+      "version": "0.1.0-rc6"
     }
   ]
 }

--- a/plugins/dwmkerr/skills/slides/references/conference-example.html
+++ b/plugins/dwmkerr/skills/slides/references/conference-example.html
@@ -713,10 +713,6 @@
     <div class="pad">
       <div class="label-in">AI</div>
       <h2 style="color:#e8503a">Maladaptive Creativity</h2>
-      <div class="diagram-stack">
-        <iframe src="drafts/mental-models/shared-mental-models.html" class="revealable diagram simple" title="Shared mental models - simple" loading="lazy"></iframe>
-        <iframe src="drafts/mental-models/shared-mental-models-complex.html" class="revealable diagram complex" title="Shared mental models - complex" loading="lazy"></iframe>
-      </div>
     </div>
   </section>
 
@@ -791,12 +787,6 @@
         <h1>Thanks</h1>
         <div class="meta" style="position:static;left:auto;bottom:auto;margin:24px 0 0">Be kind, have fun, thank-you</div>
         <div class="meta" style="position:static;left:auto;bottom:auto;margin:14px 0 0">Dave Kerr · <a href="https://github.com/dwmkerr">github.com/dwmkerr</a> · <a href="https://linkedin.com/in/dwmkerr">linkedin.com/in/dwmkerr</a> · <a href="https://dwmkerr.com">dwmkerr.com</a></div>
-      </div>
-      <div class="art">
-        <div class="frame">
-          <img src="images/linkedin-qr.svg" alt="LinkedIn QR for dwmkerr">
-        </div>
-        <div class="caption">linkedin.com/in/dwmkerr</div>
       </div>
     </div>
   </section>

--- a/plugins/toolkit/skills/skill-development/references/troubleshooting.md
+++ b/plugins/toolkit/skills/skill-development/references/troubleshooting.md
@@ -11,6 +11,7 @@ Source: [The Complete Guide to Building Skills for Claude](https://resources.ant
 | Skill won't upload | SKILL.md not exact name | Rename to exactly `SKILL.md` (case-sensitive) |
 | "Invalid frontmatter" | YAML formatting issue | Check `---` delimiters, unclosed quotes |
 | "Invalid skill name" | Name has spaces or capitals | Use kebab-case: `my-cool-skill` |
+| Frontmatter field has no effect | Underscore vs hyphen typo | See "Frontmatter field silently ignored" below |
 | Skill doesn't trigger | Description too vague | Add specific trigger phrases |
 | Skill triggers too often | Description too broad | Add negative triggers, narrow scope |
 | MCP calls fail | Connection/auth issues | Verify MCP server, test independently |
@@ -58,6 +59,31 @@ name: My Cool Skill
 # Correct
 name: my-cool-skill
 ```
+
+### Frontmatter Field Silently Ignored
+
+Skill frontmatter field names use **hyphens**, not underscores. Common typo:
+
+```yaml
+# Wrong - silently ignored, no error, no effect
+---
+name: my-skill
+user_invocable: false
+---
+
+# Correct
+---
+name: my-skill
+user-invocable: false
+---
+```
+
+Same rule applies to `allowed-tools`, `context`, and every other kebab-case field. If a field appears to have no effect despite being in the frontmatter, check for underscore-vs-hyphen typo.
+
+**Fields that use hyphens**: `user-invocable`, `allowed-tools`.
+**Fields that use snake_case in nested values** (e.g. inside `metadata`) are per your own convention - the top-level schema uses hyphens.
+
+Debug tip: if setting `user-invocable: false` still shows the skill in the slash menu, verify the plugin has reloaded (edit any file in the plugin to trigger hot reload, or restart the session).
 
 ### Skill Doesn't Trigger
 


### PR DESCRIPTION
## Summary
- **slides**: strip dead embedded refs (2 mental-model iframes + LinkedIn QR) from the bundled conference example deck so it renders clean standalone.
- **skill-development**: document the underscore-vs-hyphen frontmatter footgun (fields like `user_invocable` are silently ignored; use `user-invocable`).
- **chore**: bump plugin versions in the marketplace manifest.

Brings in the trailing working-tree changes so the tree is clean.